### PR TITLE
feat: digital logger node

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -7,6 +7,7 @@ launch_args:
     classifier: false
     ifcb_winch: false
     chanos_winch: false
+    digital_logger: false
 
 
 alerts:
@@ -262,7 +263,7 @@ web:
 digital_logger:
     username: "admin"
     password: "1234"
-    address: "192.168.1.5"
+    address: "192.168.1.2"
     outlets:
         - name: "ifcb"
           outlet: 1

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -253,3 +253,30 @@ web:
             default: -999.999 # Replace with desired default long
         defaultOnlyExample: #optional
             default: 'static_value' # No topic, making this default value permanent
+
+# Configure digital logger control
+# Status topic: /digital_logger/outlets/{outlet num}/status
+# D/L message: {"name": "camera", "status": "on"}
+# Control service: /digital_logger/control
+# C/L message: {"name": "camera", "status": "off"}
+digital_logger:
+    username: "admin"
+    password: "1234"
+    address: "192.168.1.5"
+    outlets:
+        - name: "ifcb"
+          outlet: 1
+        - name: "arm_ifcb"
+          outlet: 2
+        - name: "arm_chanos"
+          outlet: 3
+        - name: "camera"
+          outlet: 4
+        - name: "gps"
+          outlet: 5
+        - name: "ctd"
+          outlet: 6
+        - name: "winch"
+          outlet: 7
+        - name: "starlink"
+          outlet: 8

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -7,7 +7,7 @@ launch_args:
     classifier: false
     ifcb_winch: false
     chanos_winch: false
-    digital_logger: false
+    digital_logger: true
 
 
 alerts:
@@ -266,18 +266,18 @@ digital_logger: #optional
     address: "192.168.1.2"
     outlets:
         - name: "ifcb"
-          outlet: 1
+          outlet: 0
         - name: "arm_ifcb"
-          outlet: 2
+          outlet: 1
         - name: "arm_chanos"
-          outlet: 3
+          outlet: 2
         - name: "camera"
-          outlet: 4
+          outlet: 3
         - name: "gps"
-          outlet: 5
+          outlet: 4
         - name: "ctd"
-          outlet: 6
+          outlet: 5
         - name: "winch"
-          outlet: 7
+          outlet: 6
         - name: "starlink"
-          outlet: 8
+          outlet: 7

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -260,7 +260,7 @@ web:
 # D/L message: {"name": "camera", "status": "on"}
 # Control service: /digital_logger/control
 # C/L message: {"name": "camera", "status": "off"}
-digital_logger:
+digital_logger: #optional
     username: "admin"
     password: "1234"
     address: "192.168.1.2"

--- a/src/phyto_arm/CMakeLists.txt
+++ b/src/phyto_arm/CMakeLists.txt
@@ -22,6 +22,8 @@ add_message_files(
   ConductorState.msg
   ConductorStates.msg
   DepthProfile.msg
+  OutletStatus.msg
+  LoggerStatus.msg
 )
 
 add_service_files(

--- a/src/phyto_arm/CMakeLists.txt
+++ b/src/phyto_arm/CMakeLists.txt
@@ -23,7 +23,6 @@ add_message_files(
   ConductorStates.msg
   DepthProfile.msg
   OutletStatus.msg
-  LoggerStatus.msg
 )
 
 add_service_files(

--- a/src/phyto_arm/launch/main.launch
+++ b/src/phyto_arm/launch/main.launch
@@ -36,6 +36,8 @@
         </node>
     </group>
 
+    <node name="digital_logger" pkg="phyto_arm" type="digital_logger_node.py"/>
+
     <!--
     disabled
     <node name="instant_replay" pkg="phyto_arm" type="instant_replay_node.py"

--- a/src/phyto_arm/launch/main.launch
+++ b/src/phyto_arm/launch/main.launch
@@ -36,7 +36,7 @@
         </node>
     </group>
 
-    <node name="digital_logger" pkg="phyto_arm" type="digital_logger_node.py"/>
+    <node if="$(arg digital_logger)" name="digital_logger" pkg="phyto_arm" type="digital_logger_node.py"/>
 
     <!--
     disabled

--- a/src/phyto_arm/msg/LoggerStatus.msg
+++ b/src/phyto_arm/msg/LoggerStatus.msg
@@ -1,1 +1,0 @@
-OutletStatus[] statuses

--- a/src/phyto_arm/msg/LoggerStatus.msg
+++ b/src/phyto_arm/msg/LoggerStatus.msg
@@ -1,0 +1,1 @@
+OutletStatus[] statuses

--- a/src/phyto_arm/msg/OutletStatus.msg
+++ b/src/phyto_arm/msg/OutletStatus.msg
@@ -1,0 +1,2 @@
+string name
+string status

--- a/src/phyto_arm/msg/OutletStatus.msg
+++ b/src/phyto_arm/msg/OutletStatus.msg
@@ -1,2 +1,2 @@
 string name
-string status
+bool is_active

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -47,7 +47,8 @@ def main():
     rate = rospy.Rate(1)
 
     while not rospy.is_shutdown():
-        response = requests.get(f'http://{username}:{password}@{address}/restapi/relay/outlets/=0,1,2,3,4,5,6,7/state/')
+        outlet_list = ",".join(map(str, range(num_outlets)))
+        response = requests.get(f'http://{username}:{password}@{address}/restapi/relay/outlets/={outlet_list}/state/')
 
         result = json.loads(response.text)
 

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -7,6 +7,9 @@ from requests.auth import HTTPDigestAuth
 from phyto_arm.msg import OutletStatus
 
 def control_outlet(msg):
+    """
+    Send the given msg to the digital logger as an HTTP request.
+    """
     username = rospy.get_param('/digital_logger/username')
     password = rospy.get_param('/digital_logger/password')
     address = rospy.get_param('/digital_logger/address')
@@ -14,17 +17,19 @@ def control_outlet(msg):
 
     for outlet in outlets:
         if outlet['name'] == msg.name:
+            # outlet numbers in the config yaml start from 1 whereas outlet numbers in the API start from 0
             outlet_num = int(outlet['outlet']) - 1
 
     status = msg.status == 'on'
 
-    response = requests.put(f'http://{address}/restapi/relay/outlets/{outlet_num}/state/', auth=HTTPDigestAuth(username, password), data={'value': status}, headers={"X-CSRF": "x", "Accept": "application/json"})
-    rospy.logwarn(f'sent: http://{address}/restapi/relay/outlets/{outlet_num}/state/, {status}, {response.text}')
+    response = requests.put(f'http://{address}/restapi/relay/outlets/{outlet_num}/state/', auth=HTTPDigestAuth(username, password), data={'value': str(status).lower()}, headers={"X-CSRF": "x", "Accept": "application/json"})
+    rospy.loginfo(f'sent: http://{address}/restapi/relay/outlets/{outlet_num}/state/, auth={username},{password} status={str(status).lower()}, received: code {response.status_code} : {response.text}')
 
 
 def main():
     rospy.init_node('digital_logger_node')
 
+    # subscribe to the digital logger control topic
     subscriber = rospy.Subscriber('/digital_logger/control', OutletStatus, control_outlet)
 
     username = rospy.get_param('/digital_logger/username')
@@ -33,10 +38,12 @@ def main():
     outlets = rospy.get_param('/digital_logger/outlets')
     num_outlets = len(outlets)
 
+    # create an independent publisher for each outlet
     outlet_publishers = {}
     for outlet_num in range(num_outlets):
         outlet_publishers[f'outlet_{outlet_num}'] = rospy.Publisher(f'/digital_logger/outlet/{outlet_num}/status/', OutletStatus, queue_size=10)
 
+    # Monitor outlets at 1Hz
     rate = rospy.Rate(1)
 
     while not rospy.is_shutdown():
@@ -46,6 +53,7 @@ def main():
 
         assert len(result) == num_outlets
 
+        # publish the status of each outlet to its specific topic
         for outlet_index in range(len(result)):
             if result[outlet_index]:
                 status = 'on'

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -10,10 +10,10 @@ def control_outlet(msg):
     """
     Send the given msg to the digital logger as an HTTP request.
     """
-    username = rospy.get_param('/digital_logger/username')
-    password = rospy.get_param('/digital_logger/password')
-    address = rospy.get_param('/digital_logger/address')
-    outlets = rospy.get_param('/digital_logger/outlets')
+    username = rospy.get_param('~username')
+    password = rospy.get_param('~password')
+    address = rospy.get_param('~address')
+    outlets = rospy.get_param('~outlets')
 
     for outlet in outlets:
         if outlet['name'] == msg.name:
@@ -27,15 +27,15 @@ def control_outlet(msg):
 
 
 def main():
-    rospy.init_node('digital_logger_node')
+    rospy.init_node('digital_logger')
 
     # subscribe to the digital logger control topic
     subscriber = rospy.Subscriber('/digital_logger/control', OutletStatus, control_outlet)
 
-    username = rospy.get_param('/digital_logger/username')
-    password = rospy.get_param('/digital_logger/password')
-    address = rospy.get_param('/digital_logger/address')
-    outlets = rospy.get_param('/digital_logger/outlets')
+    username = rospy.get_param('~username')
+    password = rospy.get_param('~password')
+    address = rospy.get_param('~address')
+    outlets = rospy.get_param('~outlets')
     num_outlets = len(outlets)
 
     # create an independent publisher for each outlet

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -35,7 +35,7 @@ def run_digital_logger():
     rospy.init_node('digital_logger')
 
     # subscribe to the digital logger control topic
-    subscriber = rospy.Subscriber('/digital_logger/control', OutletStatus, control_outlet)
+    rospy.Subscriber('/digital_logger/control', OutletStatus, control_outlet)
 
     username = rospy.get_param('~username')
     password = rospy.get_param('~password')

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -17,8 +17,7 @@ def control_outlet(msg):
 
     for outlet in outlets:
         if outlet['name'] == msg.name:
-            # outlet numbers in the config yaml start from 1 whereas outlet numbers in the API start from 0
-            outlet_num = int(outlet['outlet']) - 1
+            outlet_num = int(outlet['outlet'])
 
     status = msg.status == 'on'
 

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -26,7 +26,12 @@ def control_outlet(msg):
     rospy.loginfo(f'sent: http://{address}/restapi/relay/outlets/{outlet_num}/state/, auth={username},{password} status={str(status).lower()}, received: code {response.status_code} : {response.text}')
 
 
-def main():
+def run_digital_logger():
+    """
+    Run the digital logger node. Publishes outlet statuses at 
+    /digital_logger/outlets/{outlet num}/status. The outlets can be controlled by publishing a 
+    OutletStatus message to /digital_logger/control. 
+    """
     rospy.init_node('digital_logger')
 
     # subscribe to the digital logger control topic
@@ -72,6 +77,6 @@ def main():
 
 if __name__ == '__main__':
     try:
-        main()
+        run_digital_logger()
     except rospy.ROSInterruptException:
         pass

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -44,9 +44,9 @@ def run_digital_logger():
     num_outlets = len(outlets)
 
     # create an independent publisher for each outlet
-    outlet_publishers = {}
+    outlet_publishers = []
     for outlet_num in range(num_outlets):
-        outlet_publishers[f'outlet_{outlet_num}'] = rospy.Publisher(f'/digital_logger/outlet/{outlet_num}/status/', OutletStatus, queue_size=10)
+        outlet_publishers.append(rospy.Publisher(f'/digital_logger/outlet/{outlet_num}/status/', OutletStatus, queue_size=10))
 
     # Monitor outlets at 1Hz
     rate = rospy.Rate(1)
@@ -60,8 +60,8 @@ def run_digital_logger():
         assert len(result) == num_outlets
 
         # publish the status of each outlet to its specific topic
-        for outlet_index in range(len(result)):
-            if result[outlet_index]:
+        for outlet_index, outlet_result in enumerate(result):
+            if outlet_result:
                 status = 'on'
             else:
                 status = 'off'
@@ -70,7 +70,7 @@ def run_digital_logger():
             outlet_status.name = outlets[outlet_index]['name']
             outlet_status.status = status
 
-            outlet_publishers[f'outlet_{outlet_index}'].publish(outlet_status)
+            outlet_publishers[outlet_index].publish(outlet_status)
 
         rate.sleep()
 

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-import rospy
 import json
+
 import requests
-from requests.auth import HTTPDigestAuth
+import rospy
 
 from phyto_arm.msg import OutletStatus
 
@@ -22,7 +22,7 @@ def control_outlet(msg):
 
     status = msg.status == 'on'
 
-    response = requests.put(f'http://{address}/restapi/relay/outlets/{outlet_num}/state/', auth=HTTPDigestAuth(username, password), data={'value': str(status).lower()}, headers={"X-CSRF": "x", "Accept": "application/json"})
+    response = requests.put(f'http://{address}/restapi/relay/outlets/{outlet_num}/state/', auth=requests.auth.HTTPDigestAuth(username, password), data={'value': str(status).lower()}, headers={"X-CSRF": "x", "Accept": "application/json"})
     rospy.loginfo(f'sent: http://{address}/restapi/relay/outlets/{outlet_num}/state/, auth={username},{password} status={str(status).lower()}, received: code {response.status_code} : {response.text}')
 
 

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import rospy
+import json
+import requests
+from requests.auth import HTTPDigestAuth
+
+from phyto_arm.msg import OutletStatus
+
+def control_outlet(msg):
+    username = rospy.get_param('/digital_logger/username')
+    password = rospy.get_param('/digital_logger/password')
+    address = rospy.get_param('/digital_logger/address')
+    outlets = rospy.get_param('/digital_logger/outlets')
+
+    for outlet in outlets:
+        if outlet['name'] == msg.name:
+            outlet_num = int(outlet['outlet']) - 1
+
+    status = msg.status == 'on'
+
+    response = requests.put(f'http://{address}/restapi/relay/outlets/{outlet_num}/state/', auth=HTTPDigestAuth(username, password), data={'value': status}, headers={"X-CSRF": "x", "Accept": "application/json"})
+    rospy.logwarn(f'sent: http://{address}/restapi/relay/outlets/{outlet_num}/state/, {status}, {response.text}')
+
+
+def main():
+    rospy.init_node('digital_logger_node')
+
+    subscriber = rospy.Subscriber('/digital_logger/control', OutletStatus, control_outlet)
+
+    username = rospy.get_param('/digital_logger/username')
+    password = rospy.get_param('/digital_logger/password')
+    address = rospy.get_param('/digital_logger/address')
+    outlets = rospy.get_param('/digital_logger/outlets')
+    num_outlets = len(outlets)
+
+    outlet_publishers = {}
+    for outlet_num in range(num_outlets):
+        outlet_publishers[f'outlet_{outlet_num}'] = rospy.Publisher(f'/digital_logger/outlet/{outlet_num}/status/', OutletStatus, queue_size=10)
+
+    rate = rospy.Rate(1)
+
+    while not rospy.is_shutdown():
+        response = requests.get(f'http://{username}:{password}@{address}/restapi/relay/outlets/=0,1,2,3,4,5,6,7/state/')
+
+        result = json.loads(response.text)
+
+        assert len(result) == num_outlets
+
+        for outlet_index in range(len(result)):
+            if result[outlet_index]:
+                status = 'on'
+            else:
+                status = 'off'
+
+            outlet_status = OutletStatus()
+            outlet_status.name = outlets[outlet_index]['name']
+            outlet_status.status = status
+
+            outlet_publishers[f'outlet_{outlet_index}'].publish(outlet_status)
+
+        rate.sleep()
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except rospy.ROSInterruptException:
+        pass

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -22,8 +22,9 @@ def control_outlet(msg):
 
     status = msg.status == 'on'
 
-    response = requests.put(f'http://{address}/restapi/relay/outlets/{outlet_num}/state/', auth=requests.auth.HTTPDigestAuth(username, password), data={'value': str(status).lower()}, headers={"X-CSRF": "x", "Accept": "application/json"})
-    rospy.loginfo(f'sent: http://{address}/restapi/relay/outlets/{outlet_num}/state/, auth={username},{password} status={str(status).lower()}, received: code {response.status_code} : {response.text}')
+    outlet_endpoint = f'http://{address}/restapi/relay/outlets/{outlet_num}/state/'
+    response = requests.put(outlet_endpoint, auth=requests.auth.HTTPDigestAuth(username, password), data={'value': str(status).lower()}, headers={"X-CSRF": "x", "Accept": "application/json"})
+    rospy.loginfo(f'sent: {outlet_endpoint}, status={str(status).lower()}, received: code {response.status_code} : {response.text}')
 
 
 def run_digital_logger():

--- a/src/phyto_arm/src/digital_logger_node.py
+++ b/src/phyto_arm/src/digital_logger_node.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+"""
+Functionality for monitoring and controlling a Digital Loggers Web Power Switch Pro model.
+"""
 import base64
 import urllib.request
 
@@ -6,94 +9,101 @@ import rospy
 
 from phyto_arm.msg import OutletStatus
 
+# Global variables relevant to digital logger control. These variables are defined once the digital
+# logger node is initialized.
+AUTH = ''
+ADDRESS = ''
+OUTLETS = ''
+OUTLET_NAMES = ''
 
-class DigitalLogger:
-    def __init__(self):
-        rospy.init_node('digital_logger')
 
-        # subscribe to the digital logger control topic
-        rospy.Subscriber('/digital_logger/control', OutletStatus, self.control_outlet)
+def control_outlet(msg):
+    """
+    Send the given msg to the digital logger as an HTTP request.
+    """
 
-        self.username = rospy.get_param('~username')
-        self.password = rospy.get_param('~password')
-        self.address = rospy.get_param('~address')
-        self.outlets = rospy.get_param('~outlets')
-        self.outlet_names = {outlet['name']: int(outlet['outlet']) for outlet in self.outlets}
+    outlet_num = OUTLET_NAMES.get(msg.name)
 
-        self.auth = f'Basic {base64.b64encode(f"{self.username}:{self.password}".encode()).decode()}'
+    data = f'value={str(msg.is_active).lower()}'
+    url = f'http://{ADDRESS}/restapi/relay/outlets/{outlet_num}/state/'
 
-        self.outlet_publishers = []
-        for outlet_num, _ in enumerate(self.outlets):
-            self.outlet_publishers.append(rospy.Publisher(f'/digital_logger/outlet/{outlet_num}/status/', OutletStatus, queue_size=10))
+    # Create a PUT request
+    req = urllib.request.Request(url, data=data.encode("utf-8"), method="PUT")
+    req.add_header("Authorization", AUTH)
+    req.add_header("X-CSRF", 'x')
 
-        # Monitor outlets at 1Hz
-        self.rate = rospy.Rate(1)
+    try:
+        # Send the PUT request
+        response = urllib.request.urlopen(req)
+    except urllib.error.HTTPError as http_err:
+        raise ValueError(f"HTTP Error: {http_err.code} : {http_err.reason}") from http_err
+    except urllib.error.URLError as url_err:
+        raise ValueError(f"URL Error: {url_err.reason}") from url_err
 
-    def run(self):
-        """
-        Run the digital logger node. Publishes outlet statuses at 
-        /digital_logger/outlets/{outlet num}/status. The outlets can be controlled by publishing a 
-        OutletStatus message to /digital_logger/control. 
-        """
-        while not rospy.is_shutdown():
-            # send a status request for each available outlet
-            for outlet_index, _ in enumerate(self.outlets):
-                # Construct request
-                url = f'http://{self.address}/restapi/relay/outlets/{outlet_index}/state/'
-                request = urllib.request.Request(url)
-                request.add_header("Authorization", self.auth)
+    result = response.read().decode('utf-8')
 
-                try:
-                    # Send the GET request
-                    with urllib.request.urlopen(request) as response:
-                        # Read and decode the response
-                        response_data = response.read().decode('utf-8')
-                except urllib.error.HTTPError as http_err:
-                    raise ValueError(f"HTTP Error: {http_err.code} : {http_err.reason}") from http_err
-                except urllib.error.URLError as url_err:
-                    raise ValueError(f"URL Error: {url_err.reason}") from url_err
+    rospy.loginfo(f'sent status={str(msg.is_active).lower()} to {ADDRESS}:{url}, received: code {response.status} : {result}')
 
-                # publish the status of each outlet to its specific topic
-                outlet_status = OutletStatus()
-                outlet_status.name = self.outlets[outlet_index]['name']
-                # DL API uses 'true' and 'false' to denote outlet status, which need to be converted to Python bools
-                outlet_status.is_active = response_data == 'true'
 
-                self.outlet_publishers[outlet_index].publish(outlet_status)
+def run_digital_logger_node():
+    """
+    Run the digital logger node. Publishes outlet statuses at 
+    /digital_logger/OUTLETS/{outlet num}/status. The OUTLETS can be controlled by publishing a 
+    OutletStatus message to /digital_logger/control. 
+    """
+    global AUTH, ADDRESS, OUTLETS, OUTLET_NAMES
 
-            self.rate.sleep()
+    rospy.init_node('digital_logger')
 
-    def control_outlet(self, msg):
-        """
-        Send the given msg to the digital logger as an HTTP request.
-        """
+    rospy.init_node('digital_logger')
+    username = rospy.get_param('~username')
+    password = rospy.get_param('~password')
+    AUTH = f"Basic {base64.b64encode(f'{username}:{password}'.encode()).decode()}"
+    ADDRESS = rospy.get_param('~address')
+    OUTLETS = rospy.get_param('~outlets')
+    OUTLET_NAMES = {outlet['name']: int(outlet['outlet']) for outlet in OUTLETS}
 
-        outlet_num = self.outlet_names.get(msg.name)
+    # subscribe to the digital logger control topic
+    rospy.Subscriber('/digital_logger/control', OutletStatus, control_outlet)
 
-        data = f'value={str(msg.is_active).lower()}'
-        url = f'http://{self.address}/restapi/relay/outlets/{outlet_num}/state/'
+    outlet_publishers = []
+    for outlet_num, _ in enumerate(OUTLETS):
+        outlet_publishers.append(rospy.Publisher(f'/digital_logger/outlet/{outlet_num}/status/', OutletStatus, queue_size=10))
 
-        # Create a PUT request
-        req = urllib.request.Request(url, data=data.encode("utf-8"), method="PUT")
-        req.add_header("Authorization", self.auth)
-        req.add_header("X-CSRF", 'x')
+    # Monitor outlets at 1Hz
+    rate = rospy.Rate(1)
 
-        try:
-            # Send the PUT request
-            response = urllib.request.urlopen(req)
-        except urllib.error.HTTPError as http_err:
-            raise ValueError(f"HTTP Error: {http_err.code} : {http_err.reason}") from http_err
-        except urllib.error.URLError as url_err:
-            raise ValueError(f"URL Error: {url_err.reason}") from url_err
+    while not rospy.is_shutdown():
+        # send a status request for each available outlet
+        for outlet_index, _ in enumerate(OUTLETS):
+            # Construct request
+            url = f'http://{ADDRESS}/restapi/relay/outlets/{outlet_index}/state/'
+            request = urllib.request.Request(url)
+            request.add_header("Authorization", AUTH)
 
-        result = response.read().decode('utf-8')
+            try:
+                # Send the GET request
+                with urllib.request.urlopen(request) as response:
+                    # Read and decode the response
+                    response_data = response.read().decode('utf-8')
+            except urllib.error.HTTPError as http_err:
+                raise ValueError(f"HTTP Error: {http_err.code} : {http_err.reason}") from http_err
+            except urllib.error.URLError as url_err:
+                raise ValueError(f"URL Error: {url_err.reason}") from url_err
 
-        rospy.loginfo(f'sent status={str(msg.is_active).lower()} to {self.address}:{url}, received: code {response.status} : {result}')
+            # publish the status of each outlet to its specific topic
+            outlet_status = OutletStatus()
+            outlet_status.name = OUTLETS[outlet_index]['name']
+            # DL API uses 'true' and 'false' to denote outlet status, which need to be converted to Python booleans
+            outlet_status.is_active = response_data == 'true'
+
+            outlet_publishers[outlet_index].publish(outlet_status)
+
+        rate.sleep()
 
 
 if __name__ == '__main__':
     try:
-        digital_logger = DigitalLogger()
-        digital_logger.run()
+        run_digital_logger_node()
     except rospy.ROSInterruptException:
         pass


### PR DESCRIPTION
Adds the digital logger node. The digital logger node will publish the statuses of each outlet as a separate topic in the form `/digital_logger/outlets/{outlet num}/status`. To change the status of an outlet, publish to the control service `/digital_logger/control` specifying an outlet name and a status ("on" or "off"). The OutletStatus message type is added to contain this information. 