### PR TITLE
refactor: Replace 'screen' use with Docker. WIP

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,12 +1,36 @@
 name: Example
 
+docker_image: whoi/phyto-arm:latest
 
-launch_args:
-    log_dir: /mnt/data/roslogs/
-    rosbag_prefix: /mnt/data/rosbags/phyto-arm
-    classifier: false
-    ifcb_winch: false
-    chanos_winch: false
+processes:
+    main:
+        enabled: true
+        volumes:
+            log_dir: /mnt/data/roslogs/
+            rosbag_dir: /mnt/data/rosbags/
+        launch_args:
+            rosbag_prefix: phyto-arm
+            classifier: false
+        tcp_ports:
+            bridge_node: 9090
+            web_node: 8098
+    arm_ifcb:
+        enabled: true
+        launch_args:
+            ifcb_winch: false
+        devices:
+            ctd_path: /dev/ttyS1
+        volumes:
+            routines_dir: /home/ifcb/IFCBacquire/Host/Routines
+            data_dir: /mnt/data/ifcbdata
+    arm_chanos:
+        enabled: false
+        launch_args:
+            chanos_winch: false
+        devices:
+            ctd_path: /dev/ttyS2
+        udp_ports:
+            rbr_port: 12345
 
 
 alerts:
@@ -28,10 +52,8 @@ ifcb:
     address: "172.17.0.1"
     port: 8092
     serial: "111-111-111"
-    routines_dir: "/routines"
     # This path is interpreted by IFCBacquire, which may be in another
     # container or namespace.
-    data_dir: "/mnt/data/ifcbdata"
 
 
 arm_ifcb:

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -6,8 +6,8 @@ processes:
     main:
         enabled: true
         volumes:
-            log_dir: /mnt/data/roslogs/
-            rosbag_dir: /mnt/data/rosbags/
+            log_dir: /data/roslogs/
+            rosbag_dir: /data/rosbags/
         launch_args:
             rosbag_prefix: phyto-arm
             classifier: false
@@ -22,7 +22,7 @@ processes:
             ctd_path: /dev/ttyS1
         volumes:
             routines_dir: /home/ifcb/IFCBacquire/Host/Routines
-            data_dir: /mnt/data/ifcbdata
+            data_dir: /data/ifcbdata
     arm_chanos:
         enabled: false
         launch_args:

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,14 +1,13 @@
 name: Example
 
 docker_image: whoi/phyto-arm:latest
+log_dir: /data/roslogs/
 
 processes:
     main:
         enabled: true
-        volumes:
-            log_dir: /data/roslogs/
-            rosbag_dir: /data/rosbags/
         launch_args:
+            rosbag_dir: /data/rosbags/
             rosbag_prefix: phyto-arm
             classifier: false
         tcp_ports:
@@ -18,11 +17,10 @@ processes:
         enabled: true
         launch_args:
             ifcb_winch: false
-        devices:
-            ctd_path: /dev/ttyS1
-        volumes:
             routines_dir: /home/ifcb/IFCBacquire/Host/Routines
             data_dir: /data/ifcbdata
+        devices:
+            ctd_path: /dev/ttyS1
     arm_chanos:
         enabled: false
         launch_args:

--- a/pa
+++ b/pa
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+PhytO-ARM Container CLI (pa)
+
+This script manages Docker containers for PhytO-ARM processes, using the original
+phyto-arm script within each container to manage ROS nodes.
+"""
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+import docker
+import yaml
+from docker.models.containers import Container
+
+def create_network(client: docker.DockerClient) -> docker.models.networks.Network:
+    """Create or get the Docker network for PhytO-ARM containers"""
+    try:
+        return client.networks.get("phyto-arm-net")
+    except docker.errors.NotFound:
+        return client.networks.create("phyto-arm-net", driver="bridge")
+
+def get_running_containers(client: docker.DockerClient) -> Dict[str, Container]:
+    """Get all running PhytO-ARM containers"""
+    containers = client.containers.list(filters={"name": "phyto-arm-"})
+    return {c.name.replace('phyto-arm-', ''): c for c in containers}
+
+def start_container(
+    client: docker.DockerClient,
+    network: docker.models.networks.Network,
+    config_path: Path,
+    process_name: str,
+    process_config: dict,
+    image_name: str
+) -> Container:
+    """Start a single PhytO-ARM container"""
+    container_name = f"phyto-arm-{process_name}"
+
+    # Base volumes that all containers need
+    volumes = {
+        str(config_path.absolute()): {
+            "bind": "/app/config.yaml",
+            "mode": "ro"
+        },
+        str(config_path.parent.absolute()): {
+            "bind": "/app/configs",
+            "mode": "ro"
+        }
+    }
+
+    # Add process-specific volumes
+    for vol_name, host_path in process_config.get('volumes', {}).items():
+        Path(host_path).mkdir(parents=True, exist_ok=True)
+        volumes[host_path] = {
+            "bind": f"/app/volumes/{vol_name}",
+            "mode": "rw"
+        }
+
+    # Handle devices
+    devices = [
+        f"{path}:{path}"
+        for path in process_config.get('devices', {}).values()
+    ]
+
+    # Handle ports
+    ports = {}
+    for port in process_config.get('tcp_ports', {}).values():
+        ports[f'{port}/tcp'] = port
+    for port in process_config.get('udp_ports', {}).values():
+        ports[f'{port}/udp'] = port
+
+    # Container configuration
+    container_config = {
+        "image": image_name,
+        "name": container_name,
+        "command": f"phyto-arm start {process_name} /app/config.yaml",
+        "detach": True,
+        "remove": True,
+        "volumes": volumes,
+        "network": network.name,
+        "devices": devices,
+        "ports": ports,
+        "environment": {
+            "DONT_SCREEN": "1", # screen is not needed within containers
+            "ROS_MASTER_URI": "http://phyto-arm-main:11311"
+        }
+    }
+
+    if process_name == "main":
+        container_config["environment"].pop("ROS_MASTER_URI")
+
+    try:
+        container = client.containers.run(**container_config)
+        print(f"Started container {container_name}")
+        return container
+    except docker.errors.APIError as e:
+        print(f"Failed to start container {container_name}: {e}")
+        raise
+
+def start_processes(config_path: Path, process_names: Optional[list[str]] = None) -> None:
+    """Start PhytO-ARM containers based on config"""
+    client = docker.DockerClient.from_env()
+
+    # Check if any containers are already running
+    running = get_running_containers(client)
+    if running and process_names:
+
+        # Check for conflicts with requested processes
+        conflicts = set(process_names) & set(running.keys())
+        if conflicts:
+            print("Some requested processes are already running:")
+            for name in conflicts:
+                print(f"  - {name}")
+            sys.exit(1)
+    elif running:
+        print("Some PhytO-ARM containers are already running:")
+        for name in running:
+            print(f"  - {name}")
+        print("Specify process names to start additional containers")
+        sys.exit(1)
+
+    # Load config
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    # Create network
+    network = create_network(client)
+
+    # Determine which processes to start
+    processes = config['processes']
+    if process_names:
+        # Validate requested processes exist
+        invalid = set(process_names) - set(processes.keys())
+        if invalid:
+            print(f"Processes not found in config: {', '.join(invalid)}")
+            sys.exit(1)
+        # Filter to only requested processes
+        processes = {k: v for k, v in processes.items() if k in process_names}
+
+    # Always start main first if it's in the list
+    if 'main' in processes:
+        start_container(
+            client, network, config_path, 'main',
+            processes['main'], config['docker_image']
+        )
+
+        # Wait for ROS master to start
+        time.sleep(10)
+
+        # Remove main so we don't start it again
+        processes.pop('main')
+
+    # Start remaining processes
+    for name, process_config in processes.items():
+        if process_config.get('enabled', True):
+            start_container(
+                client, network, config_path, name,
+                process_config, config['docker_image']
+            )
+
+        # If process is not enabled in the config, but was requested, print a warning
+        elif process_names:
+            print(f"Process {name} is not enabled in the config; skipping")
+
+def stop_processes(process_names: Optional[list[str]] = None) -> None:
+    """Stop PhytO-ARM containers"""
+    client = docker.DockerClient.from_env()
+    stoppable = get_running_containers(client)
+
+    if not stoppable:
+        print("No PhytO-ARM containers are running")
+        return
+
+    if process_names:
+
+        # Validate requested processes exist
+        invalid = set(process_names) - set(stoppable.keys())
+        if invalid:
+            print(f"Processes not running: {', '.join(invalid)}")
+            sys.exit(1)
+
+        # Filter to only requested processes
+        stoppable = {k: v for k, v in stoppable.items() if k in process_names}
+
+    for name, container in stoppable.items():
+        try:
+            container.stop()
+            print(f"Stopped {name}")
+        except docker.errors.APIError as e:
+            print(f"Failed to stop {name}: {e}")
+
+def list_processes() -> None:
+    """List running PhytO-ARM containers"""
+    client = docker.DockerClient.from_env()
+    running = get_running_containers(client)
+
+    if not running:
+        print("No PhytO-ARM containers are running")
+        return
+
+    print("Running processes:")
+    for name in running:
+        print(f"  - {name}")
+
+def attach_process(process_name: str) -> None:
+    """Attach to a running PhytO-ARM container"""
+    client = docker.DockerClient.from_env()
+    running = get_running_containers(client)
+
+    if not running:
+        print("No PhytO-ARM containers are running")
+        return
+
+    if process_name not in running:
+        print(f"Process '{process_name}' is not running")
+        print("Running processes:", ", ".join(running.keys()))
+        return
+
+    os.system(f"docker attach phyto-arm-{process_name}")
+
+def cleanup() -> None:
+    """Remove PhytO-ARM network and any stopped containers"""
+    client = docker.DockerClient.from_env()
+
+    # Remove network
+    try:
+        network = client.networks.get("phyto-arm-net")
+        network.remove()
+        print("Removed PhytO-ARM network")
+    except docker.errors.NotFound:
+        pass
+
+    # Remove any stopped containers
+    containers = client.containers.list(
+        all=True,
+        filters={"name": "phyto-arm-"}
+    )
+    for container in containers:
+        try:
+            container.remove()
+            print(f"Removed container {container.name}")
+        except docker.errors.APIError:
+            pass
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    # Start command
+    start_parser = subparsers.add_parser('start')
+    start_parser.add_argument('config', type=Path)
+    start_parser.add_argument('processes', nargs='*',
+                            help='Specific processes to start (default: all enabled)')
+
+    # Stop command
+    stop_parser = subparsers.add_parser('stop')
+    stop_parser.add_argument('processes', nargs='*',
+                          help='Specific processes to stop (default: all)')
+
+    # List command
+    subparsers.add_parser('list')
+
+    # Attach command
+    attach_parser = subparsers.add_parser('attach')
+    attach_parser.add_argument('process')
+
+    # Cleanup command
+    subparsers.add_parser('cleanup')
+
+    args = parser.parse_args()
+
+    try:
+        if args.command == 'start':
+            start_processes(args.config, args.processes)
+        elif args.command == 'stop':
+            stop_processes(args.processes)
+        elif args.command == 'list':
+            list_processes()
+        elif args.command == 'attach':
+            attach_process(args.process)
+        elif args.command == 'cleanup':
+            cleanup()
+    except docker.errors.APIError as e:
+        print(f"Docker error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\nOperation interrupted")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/pa
+++ b/pa
@@ -28,16 +28,41 @@ def get_running_containers(client: docker.DockerClient) -> Dict[str, Container]:
     containers = client.containers.list(filters={"name": "phyto-arm-"})
     return {c.name.replace('phyto-arm-', ''): c for c in containers}
 
+# This is here to wire up arguments to volume mounts to ROS launch parameters.
+# The alternative is to generate a mount automatically and pass the paths as
+# arguments to their respective launch files.
+def handle_special_volumes_by_process(process_name: str, process_config: dict) -> dict:
+    volumes = {}
+    if process_name == "main":
+        volumes[process_config['launch_args']['rosbag_dir']] = {
+            "bind": "/app/volumes/rosbags", # Must match launch file
+            "mode": "rw"
+        }
+    if process_name == "arm_ifcb":
+        volumes[process_config['launch_args']['routines_dir']] = {
+            "bind": "/app/volumes/routines", # Must match launch file
+            "mode": "ro"
+        }
+        volumes[process_config['launch_args']['data_dir']] = {
+            "bind": "/app/volumes/ifcbdata", # Must match launch file
+            "mode": "rw"
+        }
+    return volumes
+
 def start_container(
     client: docker.DockerClient,
     network: docker.models.networks.Network,
     config_path: Path,
     process_name: str,
-    process_config: dict,
-    image_name: str
+    config: dict
 ) -> Container:
     """Start a single PhytO-ARM container"""
+
+    process_config = config['processes'][process_name]
+    image_name = config['docker_image']
     container_name = f"phyto-arm-{process_name}"
+    log_dir = config['log_dir']
+    log_mount = "/app/volumes/roslogs"
 
     # Base volumes that all containers need
     volumes = {
@@ -48,16 +73,16 @@ def start_container(
         str(config_path.parent.absolute()): {
             "bind": "/app/configs",
             "mode": "ro"
+        },
+        log_dir: {
+            "bind": log_mount,
+            "mode": "rw"
         }
     }
 
     # Add process-specific volumes
-    for vol_name, host_path in process_config.get('volumes', {}).items():
-        Path(host_path).mkdir(parents=True, exist_ok=True)
-        volumes[host_path] = {
-            "bind": f"/app/volumes/{vol_name}",
-            "mode": "rw"
-        }
+    special_volumes = handle_special_volumes_by_process(process_name, process_config)
+    volumes.update(special_volumes)
 
     # Handle devices
     devices = [
@@ -85,7 +110,8 @@ def start_container(
         "ports": ports,
         "environment": {
             "DONT_SCREEN": "1", # screen is not needed within containers
-            "ROS_MASTER_URI": "http://phyto-arm-main:11311"
+            "ROS_MASTER_URI": "http://phyto-arm-main:11311",
+            "ROS_LOG_DIR": log_mount
         }
     }
 
@@ -143,8 +169,7 @@ def start_processes(config_path: Path, process_names: Optional[list[str]] = None
     # Always start main first if it's in the list
     if 'main' in processes:
         start_container(
-            client, network, config_path, 'main',
-            processes['main'], config['docker_image']
+            client, network, config_path, 'main', config
         )
 
         # Wait for ROS master to start
@@ -157,8 +182,7 @@ def start_processes(config_path: Path, process_names: Optional[list[str]] = None
     for name, process_config in processes.items():
         if process_config.get('enabled', True):
             start_container(
-                client, network, config_path, name,
-                process_config, config['docker_image']
+                client, network, config_path, name, config
             )
 
         # If process is not enabled in the config, but was requested, print a warning

--- a/phyto-arm
+++ b/phyto-arm
@@ -65,13 +65,18 @@ def prep_roslaunch(config, env, package, launchfile):
     ]
     rl_args.append(f'config_file:={os.path.abspath(args.config)}')
 
-    for launch_arg, value in config.get('launch_args', {}).items():
+    # Get process-specific launch args if they exist
+    process_config = config.get('processes', {}).get(args.launch_name, {})
+    launch_args = process_config.get('launch_args', {})
+    
+    # Add any process-specific launch args
+    for launch_arg, value in launch_args.items():
         rl_args.append(f'{launch_arg}:={value}')
 
     # Allow the config to set a launch prefix (like gdb) for nodes. We have to
     # use an environment variable for this because roslaunch will error if an
     # argument is unset, while an environment variable is option.
-    launch_prefix = config.get('launch_args', {}).get('launch_prefix')
+    launch_prefix = launch_args.get('launch_prefix')
     if launch_prefix is not None:
         env = dict(env)  # copy first
         env['LAUNCH_PREFIX'] = launch_prefix

--- a/phyto-arm
+++ b/phyto-arm
@@ -65,18 +65,18 @@ def start_container(client, image_name, network_name, config_path: str, name: st
         launch_args.append(f"{device_name}:={host_path}")
 
     # And add udp ports
-    ports = []
+    ports = {}
     for port_name, port_value in process_config.get('udp_ports', {}).items():
         if port_name in launch_args:
             raise ValueError(f"UDP port name cannot be the same as a launch arg: {port_name}")
-        ports.append(f"{port_name}:{port_value}/udp")
+        ports[f'{port_value}/udp'] = port_value
         launch_args.append(f"{port_name}:={port_value}")
 
     # Add tcp ports
     for port_name, port_value in process_config.get('tcp_ports', {}).items():
         if port_name in launch_args:
             raise ValueError(f"TCP port name cannot be the same as a launch arg: {port_name}")
-        ports.append(f"{port_name}:{port_value}/tcp")
+        ports[f'{port_value}/tcp'] = port_value
         launch_args.append(f"{port_name}:={port_value}")
 
     # Build the roslaunch command based on container type
@@ -156,8 +156,9 @@ def start(args):
         print(f'Validating config file {args.config} against {args.config_schema}...')
         if not validate_config(args.config, args.config_schema):
             sys.exit(1)
+        print('Config is valid')
     
-    image_name = config['docker']['image']
+    image_name = config.get('docker_image') or config.get('docker', {}).get('image')
     containers = {}
     
     def cleanup():

--- a/phyto-arm
+++ b/phyto-arm
@@ -1,251 +1,233 @@
 #!/usr/bin/env python3
+'''
+This script is used to launch the PhytO-ARM software.
+
+It reads the system configuration from the provided config file and starts the
+ROS nodes with the appropriate settings.
+
+The nodes are mostly started by roslaunch, with the notable exception of
+`rosbag record`, which we want to keep recording at all costs.
+'''
 import argparse
 import atexit
 import json
 import os
+import shlex
+import subprocess
 import sys
 import urllib.request
-from pathlib import Path
 
-import docker
 import yaml
 
 from scripts.config_validation import validate_config
 
-def create_network(client):
-    """Create or get the Docker network for PhytO-ARM containers"""
-    try:
-        return client.networks.get("phyto-arm-net")
-    except docker.errors.NotFound:
-        return client.networks.create("phyto-arm-net", driver="bridge")
-
-def start_container(client, image_name, network_name, config_path: str, name: str, process_config: dict) -> docker.models.containers.Container:
-    container_name = f"phyto-arm-{name}"
-    
-    # Base volumes that all containers need
-    volumes = {
-        str(Path(config_path).absolute()): {
-            "bind": "/app/mounted_config.yaml",
-            "mode": "ro"
-        },
-        str(Path("configs").absolute()): {
-            "bind": "/app/configs",
-            "mode": "ro"
-        }
-    }
-    
-    # Convert launch args to roslaunch arguments
-    launch_args = []
-    for key, value in process_config.get('launch_args', {}).items():
-        launch_args.append(f"{key}:={value}")
-    launch_args_str = " ".join(launch_args)
-
-    # Convert paths to volumes and add to launch args
-    for vol_name, host_path in process_config.get('volumes', {}).items():
-        if vol_name in launch_args:
-            raise ValueError(f"Volume name cannot be the same as a launch arg: {vol_name}")
-
-        # Ensure the host directory exists
-        Path(host_path).mkdir(parents=True, exist_ok=True)
-
-        # Mount within '/app/volumes' in the container
-        mounted_path = f"/app/volumes/{vol_name}"
-        volumes[host_path] = {"bind": mounted_path, "mode": "rw"}
-
-        # Add the volume to the launch args
-        launch_args.append(f"{vol_name}:={mounted_path}")
-
-    # Likewise, check for devices, mount them, and add to launch args
-    devices = []
-    for device_name, host_path in process_config.get('devices', {}).items():
-        if device_name in launch_args:
-            raise ValueError(f"Device name cannot be the same as a launch arg: {device_name}")
-        # Maintain the host path
-        devices.append(f"{host_path}:{host_path}:r")
-        launch_args.append(f"{device_name}:={host_path}")
-
-    # And add udp ports
-    ports = {}
-    for port_name, port_value in process_config.get('udp_ports', {}).items():
-        if port_name in launch_args:
-            raise ValueError(f"UDP port name cannot be the same as a launch arg: {port_name}")
-        ports[f'{port_value}/udp'] = port_value
-        launch_args.append(f"{port_name}:={port_value}")
-
-    # Add tcp ports
-    for port_name, port_value in process_config.get('tcp_ports', {}).items():
-        if port_name in launch_args:
-            raise ValueError(f"TCP port name cannot be the same as a launch arg: {port_name}")
-        ports[f'{port_value}/tcp'] = port_value
-        launch_args.append(f"{port_name}:={port_value}")
-
-    # Build the roslaunch command based on container type
-    if name == "main":
-        command = f"""bash -c "
-            source devel/setup.bash &&
-            roscore &
-            sleep 5 &&
-            roslaunch --wait phyto_arm rosbag.launch config_file:=/app/mounted_config.yaml {launch_args_str} &&
-            roslaunch --wait phyto_arm main.launch config_file:=/app/mounted_config.yaml {launch_args_str}
-        " """
-    else:
-        command = f"""bash -c "
-            source devel/setup.bash &&
-            roslaunch --wait phyto_arm {name}.launch config_file:=/app/mounted_config.yaml {launch_args_str}
-        " """
-
-    # Base container configuration
-    container_config = {
-        "image": image_name,
-        "name": container_name,
-        "command": command,
-        "detach": True,
-        "remove": True,
-        "volumes": volumes,
-        "network": network_name,
-        "devices": devices,
-        "ports": ports,
-        "environment": {
-            "ROS_MASTER_URI": "http://phyto-arm-main:11311"  # Point to main container
-        }
+# Load the virtual environment and Catkin workspace and return the resulting
+# environment
+def prep_environment():
+    # Due to a long-standing bug in the setup.sh script, we must provide to the
+    # devel/ directory in the _CATKIN_SETUP_DIR environment variable.
+    #
+    # This also needs to be an absolute path so that Python can locate packages.
+    #
+    # Ref: https://github.com/catkin/catkin_tools/issues/376
+    parent_dir = os.path.dirname(__file__)
+    setup_dir = os.path.abspath(os.path.join(parent_dir, 'devel'))
+    env = {
+        '_CATKIN_SETUP_DIR': setup_dir
     }
 
-    if name == "main":
-        # Main container doesn't need ROS_MASTER_URI
-        container_config["environment"] = {}
+    # Build command to load the catkin workspace (and optionally a virtual
+    # environment) and dump the environment.
+    command = f'. {shlex.quote(setup_dir)}/setup.sh && env'
 
-    # Start the container
-    try:
-        container = client.containers.run(**container_config)
-        print(f"Started container {container_name}")
-        return container
-    except docker.errors.APIError as e:
-        print(f"Failed to start container {container_name}: {e}")
-        raise
+    if os.getenv('NO_VIRTUALENV') is None:
+        command = f'. {shlex.quote(parent_dir)}/.venv/bin/activate && ' + \
+                  command
 
-def stop_container(container) -> None:
-    try:
-        container.stop()
-        print(f"Stopped container {container.name}")
-    except docker.errors.APIError as e:
-        print(f"Failed to stop container {container.name}: {e}")
+    # Dump the environment and parse the output
+    env_out = subprocess.check_output(command, shell=True, env=env)
+    for line in env_out.rstrip().split(b'\n'):
+        var, _, value = line.partition(b'=')
+        env[var] = value
 
-def send_alerts(config) -> None:
-    """Send alerts when stopping the system"""
-    for alert in config.get('alerts', []):
-        if alert['type'] == 'slack' and alert.get('url'):
-            try:
-                urllib.request.urlopen(
-                    alert['url'],
-                    json.dumps({
-                        'text': f'*PhytO-ARM process stopped*\n - Deployment: _{config.get("name", "unknown")}_ \n'
-                    }).encode()
-                )
-            except Exception as e:
-                print(f"Failed to send alert: {e}")
+    return env
 
-def start(args):
-    client = docker.from_env()
-    network = create_network(client)
-    
-    with open(args.config, 'r') as f:
-        config = yaml.safe_load(f)
-    
-    # Validate config
-    if not args.skip_validation:
-        print(f'Validating config file {args.config} against {args.config_schema}...')
-        if not validate_config(args.config, args.config_schema):
-            sys.exit(1)
-        print('Config is valid')
-    
-    image_name = config.get('docker_image') or config.get('docker', {}).get('image')
-    containers = {}
-    
-    def cleanup():
-        for container in containers.values():
-            stop_container(container)
-        try:
-            network.remove()
-        except docker.errors.APIError:
-            pass
-        send_alerts(config)
-    
-    # Register cleanup on exit
-    atexit.register(cleanup)
-    
-    # Start main container first
-    main_process = config['processes'].get('main', None)
-    if main_process and main_process.get('enabled', True):
-        containers['main'] = start_container(client, image_name, network.name, args.config, 'main', main_process)
-    else:
-        print("Main process not found or not enabled in config")
-        sys.exit(1)
 
-    # Give main container time to start roscore
-    print("Waiting for main container to start...")
-    import time
-    time.sleep(10)
+# Prepare a command and environment for roslaunch
+def prep_roslaunch(config, env, package, launchfile):
+    # Build the command-line arguments for roslaunch
+    rl_args = [
+        'roslaunch',
+        '--wait',  # because we can start the ROS master ourselves
+        '--required',  # stop if any process fails
+        '--skip-log-check',
+        package, launchfile
+    ]
+    rl_args.append(f'config_file:={os.path.abspath(args.config)}')
 
-    # Start other enabled processes
-    for process_name, process_args in config['processes'].items():
-        if process_name != 'main' and process_args.get('enabled', True):
-            containers[process_name] = start_container(client, image_name, network.name, args.config, process_name, process_args)
+    for launch_arg, value in config.get('launch_args', {}).items():
+        rl_args.append(f'{launch_arg}:={value}')
 
-def stop():
-    client = docker.from_env()
-    containers = client.containers.list(filters={"name": "phyto-arm-"})
+    # Allow the config to set a launch prefix (like gdb) for nodes. We have to
+    # use an environment variable for this because roslaunch will error if an
+    # argument is unset, while an environment variable is option.
+    launch_prefix = config.get('launch_args', {}).get('launch_prefix')
+    if launch_prefix is not None:
+        env = dict(env)  # copy first
+        env['LAUNCH_PREFIX'] = launch_prefix
 
-    if not containers:
-        print("No running PhytO-ARM containers found")
-        return
+    # Build the command to invoke as an escaped string
+    # For straceing signals: strace -f -o signals.log -tt -e trace=none
+    command = ' '.join(shlex.quote(a) for a in rl_args)
+    return command, env
 
-    # If no specific container specified, stop all
-    for container in containers:
-        stop_container(container)
+
+# Send alerts when the program stops
+def send_alerts(alert_config, deployment, launch_name):
+    for alert in alert_config:
+        assert alert['type'] == 'slack' and alert['url']
+        urllib.request.urlopen(
+            alert['url'],
+            json.dumps({
+                'text': f'*PhytO-ARM process stopped*\n - Deployment: _{deployment}_ \n - Process: _{launch_name}_'
+            }).encode()
+        )
+
 
 def attach(args):
-    client = docker.from_env()
-    containers = client.containers.list(filters={"name": "phyto-arm-"})
+    os.execl('/bin/sh', '/bin/sh', '-c', 'screen -r phyto-arm')
 
-    if not containers:
-        print("No running PhytO-ARM containers found")
+
+def _start(args):
+    # Validate config file
+    if not args.skip_validation:
+        print(f'Validating config file {args.config} against {args.config_schema}...')
+        if validate_config(args.config, args.config_schema):
+            print('Config file is valid')
+        else:
+            sys.exit(1)
+
+    # Load the config file
+    with open(args.config, 'rb') as f:
+        config = yaml.safe_load(f)
+
+    # Prepare the environment
+    env = prep_environment()
+
+    # Define an atexit handler that can be used to terminate subprocesses.
+    # Recall that these handlers are invoked in reverse order, so since we start
+    # roscore first, it is last to be terminated.
+    def cleanup(name, proc, dont_kill=False):
+        if proc.returncode is not None:  # already dead
+            return
+
+        try:
+            print(f'terminating {name} ({proc.pid})')
+            proc.terminate()
+            proc.wait(5.0)
+        except subprocess.TimeoutExpired:
+            if dont_kill:
+                print(f'failed to terminate {name} ({proc.pid}), '
+                        'but refusing to kill')
+            else:
+                print(f'failed to terminate {name} ({proc.pid}), killing')
+                proc.kill()
+
+            proc.wait()
+            print(f'{name} ({proc.pid}) eventually exited')
+
+    # Set up alerts for when we terminate
+    atexit.register(send_alerts, config.get('alerts', []), config.get('name'), args.launch_name)
+
+    # Allow the config to override where logs are stored
+    log_dir = config.get('launch_args', {}).get('log_dir')
+    if log_dir is not None:
+        env['ROS_LOG_DIR'] = log_dir
+
+    # The following should only launch once, with the main PhytO-ARM processes
+    roscore = None
+    if args.launch_name == "main":
+        # Before we continue compress any older log files
+        #print('Compressing older logs')
+        #os.system(f'find {shlex.quote(log_dir)} -iname \*.log -exec gzip {{}} \;')
+
+        # Start the ROS core processes (ROS master, etc.)
+        roscore = subprocess.Popen('roscore', env=env)
+        atexit.register(lambda: cleanup('roscore', roscore))
+
+        # Start the rosbag logging process. We run this separately from the main
+        # launch file so that if the main nodes crash, we don't terminate the rosbag
+        # prematurely.
+        command, env = prep_roslaunch(config, env, 'phyto_arm', 'rosbag.launch')
+        rosbag = subprocess.Popen(command, shell=True, env=env)
+        atexit.register(lambda: cleanup('rosbag record', rosbag, dont_kill=True))
+
+    # Prepare our roslaunch command
+    command, env = prep_roslaunch(config, env, 'phyto_arm', f'{args.launch_name}.launch')
+    nodes = subprocess.Popen(command, shell=True, env=env)
+    atexit.register(lambda: cleanup('nodes', nodes))
+
+    # Wait for any child to terminate
+    pid, status = os.wait()
+
+    # Since we called wait() behind subprocess's back, we need to inform it that
+    # the process terminated. A little hacky.
+    for proc in [roscore, rosbag, nodes]:
+        if proc is not None and proc.pid == pid:
+            proc.returncode = os.WEXITSTATUS(status) \
+                              if os.WIFEXITED(status) else -1
+
+    # The atexit handlers will terminate the other subprocesses
+    pass
+
+
+def start(args):
+    # Use an environment variable to bypass wrapping the process in screen
+    if os.getenv('DONT_SCREEN'):
+        return _start(args)
+    os.environ['DONT_SCREEN'] = '1'
+
+    # Check if there is a screen session running already
+    try:
+        subprocess.check_call(
+            ['screen', '-list', 'phyto-arm'],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        print('PhytO-ARM appears to be running already, aborting')
         return
+    except subprocess.CalledProcessError:
+        pass
 
-    # If no specific container specified, attach to main
-    container_name = f"phyto-arm-{args.name}" if args.name else "phyto-arm-main"
+    # Re-run this command in a screen session
+    command = 'screen -L -dmS phyto-arm ' + \
+              ' '.join(shlex.quote(a) for a in sys.argv)
+    os.execl('/bin/sh', '/bin/sh', '-c', command)
 
-    # Find the requested container
-    container = next((c for c in containers if c.name == container_name), None)
-    if not container:
-        print(f"Container {container_name} not found")
-        return
 
-    # Attach to the container
-    os.system(f"docker attach {container.id}")
+def stop(args):
+    os.execl('/bin/sh', '/bin/sh', '-c', 'screen -S phyto-arm -X quit')
+
 
 if __name__ == '__main__':
+    # Parse command-line arguments
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest='command', required=True)
 
-    # Start command
+    attach_parser = subparsers.add_parser('attach')
+
     start_parser = subparsers.add_parser('start')
+    start_parser.add_argument('launch_name')
     start_parser.add_argument('config')
     start_parser.add_argument('--config_schema', default='./configs/example.yaml')
     start_parser.add_argument('--skip_validation', action='store_true')
 
-    # Stop command
     stop_parser = subparsers.add_parser('stop')
-    stop_parser.add_argument('config')
 
-    # Attach command
-    attach_parser = subparsers.add_parser('attach')
-    attach_parser.add_argument('name', nargs='?', help='Container name to attach to (defaults to main)')
-
-    parsed_args = parser.parse_args()
+    args = parser.parse_args()
 
     # Invoke the handler for this subcommand
     {
-        'start': start,
-        'stop': stop,
         'attach': attach,
-    }[parsed_args.command](parsed_args)
+        'start': start,
+        'stop':  stop,
+    }[args.command](args)

--- a/phyto-arm
+++ b/phyto-arm
@@ -1,233 +1,250 @@
 #!/usr/bin/env python3
-'''
-This script is used to launch the PhytO-ARM software.
-
-It reads the system configuration from the provided config file and starts the
-ROS nodes with the appropriate settings.
-
-The nodes are mostly started by roslaunch, with the notable exception of
-`rosbag record`, which we want to keep recording at all costs.
-'''
 import argparse
 import atexit
 import json
 import os
-import shlex
-import subprocess
 import sys
 import urllib.request
+from pathlib import Path
 
+import docker
 import yaml
 
 from scripts.config_validation import validate_config
 
-# Load the virtual environment and Catkin workspace and return the resulting
-# environment
-def prep_environment():
-    # Due to a long-standing bug in the setup.sh script, we must provide to the
-    # devel/ directory in the _CATKIN_SETUP_DIR environment variable.
-    #
-    # This also needs to be an absolute path so that Python can locate packages.
-    #
-    # Ref: https://github.com/catkin/catkin_tools/issues/376
-    parent_dir = os.path.dirname(__file__)
-    setup_dir = os.path.abspath(os.path.join(parent_dir, 'devel'))
-    env = {
-        '_CATKIN_SETUP_DIR': setup_dir
+def create_network(client):
+    """Create or get the Docker network for PhytO-ARM containers"""
+    try:
+        return client.networks.get("phyto-arm-net")
+    except docker.errors.NotFound:
+        return client.networks.create("phyto-arm-net", driver="bridge")
+
+def start_container(client, image_name, network_name, config_path: str, name: str, process_config: dict) -> docker.models.containers.Container:
+    container_name = f"phyto-arm-{name}"
+    
+    # Base volumes that all containers need
+    volumes = {
+        str(Path(config_path).absolute()): {
+            "bind": "/app/mounted_config.yaml",
+            "mode": "ro"
+        },
+        str(Path("configs").absolute()): {
+            "bind": "/app/configs",
+            "mode": "ro"
+        }
+    }
+    
+    # Convert launch args to roslaunch arguments
+    launch_args = []
+    for key, value in process_config.get('launch_args', {}).items():
+        launch_args.append(f"{key}:={value}")
+    launch_args_str = " ".join(launch_args)
+
+    # Convert paths to volumes and add to launch args
+    for vol_name, host_path in process_config.get('volumes', {}).items():
+        if vol_name in launch_args:
+            raise ValueError(f"Volume name cannot be the same as a launch arg: {vol_name}")
+
+        # Ensure the host directory exists
+        Path(host_path).mkdir(parents=True, exist_ok=True)
+
+        # Mount within '/app/volumes' in the container
+        mounted_path = f"/app/volumes/{vol_name}"
+        volumes[host_path] = {"bind": mounted_path, "mode": "rw"}
+
+        # Add the volume to the launch args
+        launch_args.append(f"{vol_name}:={mounted_path}")
+
+    # Likewise, check for devices, mount them, and add to launch args
+    devices = []
+    for device_name, host_path in process_config.get('devices', {}).items():
+        if device_name in launch_args:
+            raise ValueError(f"Device name cannot be the same as a launch arg: {device_name}")
+        # Maintain the host path
+        devices.append(f"{host_path}:{host_path}:r")
+        launch_args.append(f"{device_name}:={host_path}")
+
+    # And add udp ports
+    ports = []
+    for port_name, port_value in process_config.get('udp_ports', {}).items():
+        if port_name in launch_args:
+            raise ValueError(f"UDP port name cannot be the same as a launch arg: {port_name}")
+        ports.append(f"{port_name}:{port_value}/udp")
+        launch_args.append(f"{port_name}:={port_value}")
+
+    # Add tcp ports
+    for port_name, port_value in process_config.get('tcp_ports', {}).items():
+        if port_name in launch_args:
+            raise ValueError(f"TCP port name cannot be the same as a launch arg: {port_name}")
+        ports.append(f"{port_name}:{port_value}/tcp")
+        launch_args.append(f"{port_name}:={port_value}")
+
+    # Build the roslaunch command based on container type
+    if name == "main":
+        command = f"""bash -c "
+            source devel/setup.bash &&
+            roscore &
+            sleep 5 &&
+            roslaunch --wait phyto_arm rosbag.launch config_file:=/app/mounted_config.yaml {launch_args_str} &&
+            roslaunch --wait phyto_arm main.launch config_file:=/app/mounted_config.yaml {launch_args_str}
+        " """
+    else:
+        command = f"""bash -c "
+            source devel/setup.bash &&
+            roslaunch --wait phyto_arm {name}.launch config_file:=/app/mounted_config.yaml {launch_args_str}
+        " """
+
+    # Base container configuration
+    container_config = {
+        "image": image_name,
+        "name": container_name,
+        "command": command,
+        "detach": True,
+        "remove": True,
+        "volumes": volumes,
+        "network": network_name,
+        "devices": devices,
+        "ports": ports,
+        "environment": {
+            "ROS_MASTER_URI": "http://phyto-arm-main:11311"  # Point to main container
+        }
     }
 
-    # Build command to load the catkin workspace (and optionally a virtual
-    # environment) and dump the environment.
-    command = f'. {shlex.quote(setup_dir)}/setup.sh && env'
+    if name == "main":
+        # Main container doesn't need ROS_MASTER_URI
+        container_config["environment"] = {}
 
-    if os.getenv('NO_VIRTUALENV') is None:
-        command = f'. {shlex.quote(parent_dir)}/.venv/bin/activate && ' + \
-                  command
+    # Start the container
+    try:
+        container = client.containers.run(**container_config)
+        print(f"Started container {container_name}")
+        return container
+    except docker.errors.APIError as e:
+        print(f"Failed to start container {container_name}: {e}")
+        raise
 
-    # Dump the environment and parse the output
-    env_out = subprocess.check_output(command, shell=True, env=env)
-    for line in env_out.rstrip().split(b'\n'):
-        var, _, value = line.partition(b'=')
-        env[var] = value
+def stop_container(container) -> None:
+    try:
+        container.stop()
+        print(f"Stopped container {container.name}")
+    except docker.errors.APIError as e:
+        print(f"Failed to stop container {container.name}: {e}")
 
-    return env
-
-
-# Prepare a command and environment for roslaunch
-def prep_roslaunch(config, env, package, launchfile):
-    # Build the command-line arguments for roslaunch
-    rl_args = [
-        'roslaunch',
-        '--wait',  # because we can start the ROS master ourselves
-        '--required',  # stop if any process fails
-        '--skip-log-check',
-        package, launchfile
-    ]
-    rl_args.append(f'config_file:={os.path.abspath(args.config)}')
-
-    for launch_arg, value in config.get('launch_args', {}).items():
-        rl_args.append(f'{launch_arg}:={value}')
-
-    # Allow the config to set a launch prefix (like gdb) for nodes. We have to
-    # use an environment variable for this because roslaunch will error if an
-    # argument is unset, while an environment variable is option.
-    launch_prefix = config.get('launch_args', {}).get('launch_prefix')
-    if launch_prefix is not None:
-        env = dict(env)  # copy first
-        env['LAUNCH_PREFIX'] = launch_prefix
-
-    # Build the command to invoke as an escaped string
-    # For straceing signals: strace -f -o signals.log -tt -e trace=none
-    command = ' '.join(shlex.quote(a) for a in rl_args)
-    return command, env
-
-
-# Send alerts when the program stops
-def send_alerts(alert_config, deployment, launch_name):
-    for alert in alert_config:
-        assert alert['type'] == 'slack' and alert['url']
-        urllib.request.urlopen(
-            alert['url'],
-            json.dumps({
-                'text': f'*PhytO-ARM process stopped*\n - Deployment: _{deployment}_ \n - Process: _{launch_name}_'
-            }).encode()
-        )
-
-
-def attach(args):
-    os.execl('/bin/sh', '/bin/sh', '-c', 'screen -r phyto-arm')
-
-
-def _start(args):
-    # Validate config file
-    if not args.skip_validation:
-        print(f'Validating config file {args.config} against {args.config_schema}...')
-        if validate_config(args.config, args.config_schema):
-            print('Config file is valid')
-        else:
-            sys.exit(1)
-
-    # Load the config file
-    with open(args.config, 'rb') as f:
-        config = yaml.safe_load(f)
-
-    # Prepare the environment
-    env = prep_environment()
-
-    # Define an atexit handler that can be used to terminate subprocesses.
-    # Recall that these handlers are invoked in reverse order, so since we start
-    # roscore first, it is last to be terminated.
-    def cleanup(name, proc, dont_kill=False):
-        if proc.returncode is not None:  # already dead
-            return
-
-        try:
-            print(f'terminating {name} ({proc.pid})')
-            proc.terminate()
-            proc.wait(5.0)
-        except subprocess.TimeoutExpired:
-            if dont_kill:
-                print(f'failed to terminate {name} ({proc.pid}), '
-                        'but refusing to kill')
-            else:
-                print(f'failed to terminate {name} ({proc.pid}), killing')
-                proc.kill()
-
-            proc.wait()
-            print(f'{name} ({proc.pid}) eventually exited')
-
-    # Set up alerts for when we terminate
-    atexit.register(send_alerts, config.get('alerts', []), config.get('name'), args.launch_name)
-
-    # Allow the config to override where logs are stored
-    log_dir = config.get('launch_args', {}).get('log_dir')
-    if log_dir is not None:
-        env['ROS_LOG_DIR'] = log_dir
-
-    # The following should only launch once, with the main PhytO-ARM processes
-    roscore = None
-    if args.launch_name == "main":
-        # Before we continue compress any older log files
-        #print('Compressing older logs')
-        #os.system(f'find {shlex.quote(log_dir)} -iname \*.log -exec gzip {{}} \;')
-
-        # Start the ROS core processes (ROS master, etc.)
-        roscore = subprocess.Popen('roscore', env=env)
-        atexit.register(lambda: cleanup('roscore', roscore))
-
-        # Start the rosbag logging process. We run this separately from the main
-        # launch file so that if the main nodes crash, we don't terminate the rosbag
-        # prematurely.
-        command, env = prep_roslaunch(config, env, 'phyto_arm', 'rosbag.launch')
-        rosbag = subprocess.Popen(command, shell=True, env=env)
-        atexit.register(lambda: cleanup('rosbag record', rosbag, dont_kill=True))
-
-    # Prepare our roslaunch command
-    command, env = prep_roslaunch(config, env, 'phyto_arm', f'{args.launch_name}.launch')
-    nodes = subprocess.Popen(command, shell=True, env=env)
-    atexit.register(lambda: cleanup('nodes', nodes))
-
-    # Wait for any child to terminate
-    pid, status = os.wait()
-
-    # Since we called wait() behind subprocess's back, we need to inform it that
-    # the process terminated. A little hacky.
-    for proc in [roscore, rosbag, nodes]:
-        if proc is not None and proc.pid == pid:
-            proc.returncode = os.WEXITSTATUS(status) \
-                              if os.WIFEXITED(status) else -1
-
-    # The atexit handlers will terminate the other subprocesses
-    pass
-
+def send_alerts(config) -> None:
+    """Send alerts when stopping the system"""
+    for alert in config.get('alerts', []):
+        if alert['type'] == 'slack' and alert.get('url'):
+            try:
+                urllib.request.urlopen(
+                    alert['url'],
+                    json.dumps({
+                        'text': f'*PhytO-ARM process stopped*\n - Deployment: _{config.get("name", "unknown")}_ \n'
+                    }).encode()
+                )
+            except Exception as e:
+                print(f"Failed to send alert: {e}")
 
 def start(args):
-    # Use an environment variable to bypass wrapping the process in screen
-    if os.getenv('DONT_SCREEN'):
-        return _start(args)
-    os.environ['DONT_SCREEN'] = '1'
+    client = docker.from_env()
+    network = create_network(client)
+    
+    with open(args.config, 'r') as f:
+        config = yaml.safe_load(f)
+    
+    # Validate config
+    if not args.skip_validation:
+        print(f'Validating config file {args.config} against {args.config_schema}...')
+        if not validate_config(args.config, args.config_schema):
+            sys.exit(1)
+    
+    image_name = config['docker']['image']
+    containers = {}
+    
+    def cleanup():
+        for container in containers.values():
+            stop_container(container)
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+        send_alerts(config)
+    
+    # Register cleanup on exit
+    atexit.register(cleanup)
+    
+    # Start main container first
+    main_process = config['processes'].get('main', None)
+    if main_process and main_process.get('enabled', True):
+        containers['main'] = start_container(client, image_name, network.name, args.config, 'main', main_process)
+    else:
+        print("Main process not found or not enabled in config")
+        sys.exit(1)
 
-    # Check if there is a screen session running already
-    try:
-        subprocess.check_call(
-            ['screen', '-list', 'phyto-arm'],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-        )
-        print('PhytO-ARM appears to be running already, aborting')
+    # Give main container time to start roscore
+    print("Waiting for main container to start...")
+    import time
+    time.sleep(10)
+
+    # Start other enabled processes
+    for process_name, process_args in config['processes'].items():
+        if process_name != 'main' and process_args.get('enabled', True):
+            containers[process_name] = start_container(client, image_name, network.name, args.config, process_name, process_args)
+
+def stop():
+    client = docker.from_env()
+    containers = client.containers.list(filters={"name": "phyto-arm-"})
+
+    if not containers:
+        print("No running PhytO-ARM containers found")
         return
-    except subprocess.CalledProcessError:
-        pass
 
-    # Re-run this command in a screen session
-    command = 'screen -L -dmS phyto-arm ' + \
-              ' '.join(shlex.quote(a) for a in sys.argv)
-    os.execl('/bin/sh', '/bin/sh', '-c', command)
+    # If no specific container specified, stop all
+    for container in containers:
+        stop_container(container)
 
+def attach(args):
+    client = docker.from_env()
+    containers = client.containers.list(filters={"name": "phyto-arm-"})
 
-def stop(args):
-    os.execl('/bin/sh', '/bin/sh', '-c', 'screen -S phyto-arm -X quit')
+    if not containers:
+        print("No running PhytO-ARM containers found")
+        return
 
+    # If no specific container specified, attach to main
+    container_name = f"phyto-arm-{args.name}" if args.name else "phyto-arm-main"
+
+    # Find the requested container
+    container = next((c for c in containers if c.name == container_name), None)
+    if not container:
+        print(f"Container {container_name} not found")
+        return
+
+    # Attach to the container
+    os.system(f"docker attach {container.id}")
 
 if __name__ == '__main__':
-    # Parse command-line arguments
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest='command', required=True)
 
-    attach_parser = subparsers.add_parser('attach')
-
+    # Start command
     start_parser = subparsers.add_parser('start')
-    start_parser.add_argument('launch_name')
     start_parser.add_argument('config')
     start_parser.add_argument('--config_schema', default='./configs/example.yaml')
     start_parser.add_argument('--skip_validation', action='store_true')
 
+    # Stop command
     stop_parser = subparsers.add_parser('stop')
+    stop_parser.add_argument('config')
 
-    args = parser.parse_args()
+    # Attach command
+    attach_parser = subparsers.add_parser('attach')
+    attach_parser.add_argument('name', nargs='?', help='Container name to attach to (defaults to main)')
+
+    parsed_args = parser.parse_args()
 
     # Invoke the handler for this subcommand
     {
-        'attach': attach,
         'start': start,
-        'stop':  stop,
-    }[args.command](args)
+        'stop': stop,
+        'attach': attach,
+    }[parsed_args.command](parsed_args)

--- a/src/phyto_arm/launch/arm_chanos.launch
+++ b/src/phyto_arm/launch/arm_chanos.launch
@@ -6,7 +6,7 @@
     <group ns="arm_chanos">
         <!-- proxy for publishing RBR's UDP stream as ROS topic -->
         <node name="rbr_udp" pkg="rbr_maestro3_ctd" type="udp_to_ros.py">
-            <param name="port" type="int" value="12345" />
+            <param name="port" type="int" value="$(arg rbr_port)" />
         </node>
 
         <node name="ctd" pkg="rbr_maestro3_ctd" type="rbr_maestro3_node.py">

--- a/src/phyto_arm/launch/arm_ifcb.launch
+++ b/src/phyto_arm/launch/arm_ifcb.launch
@@ -2,7 +2,10 @@
     <!-- Most settings are in config.yaml, which is easier to edit. -->
     <rosparam command="load" file="$(arg config_file)" />
 
-    <node name="ifcb" pkg="ifcb" type="ifcb" />
+    <node name="ifcb" pkg="ifcb" type="ifcb">
+        <param name="routines_dir" value="$(arg routines_dir)" />
+        <param name="data_dir" value="$(arg data_dir)" />
+    </node>
 
     <node name="ifcb_logfilter" pkg="ifcb" type="ifcb_logfilter" />
 

--- a/src/phyto_arm/launch/arm_ifcb.launch
+++ b/src/phyto_arm/launch/arm_ifcb.launch
@@ -3,8 +3,8 @@
     <rosparam command="load" file="$(arg config_file)" />
 
     <node name="ifcb" pkg="ifcb" type="ifcb">
-        <param name="routines_dir" value="$(arg routines_dir)" />
-        <param name="data_dir" value="$(arg data_dir)" />
+        <param name="routines_dir" value="/app/volumes/routines" />
+        <param name="data_dir" value="/app/volumes/ifcbdata" />
     </node>
 
     <node name="ifcb_logfilter" pkg="ifcb" type="ifcb_logfilter" />

--- a/src/phyto_arm/launch/main.launch
+++ b/src/phyto_arm/launch/main.launch
@@ -7,6 +7,7 @@
 
     <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
         <arg name="use_compression" value="true" />
+        <arg name="port" value="$(arg bridge_node)" />
     </include>
 
     <node name="lock_manager" pkg="phyto_arm" type="lock_manager.py" />
@@ -22,7 +23,9 @@
         <remap from="/extended_fix" to="~extended_fix" />
     </node>
 
-    <node name="web" pkg="phyto_arm" type="web_node.py" />
+    <node name="web" pkg="phyto_arm" type="web_node.py">
+        <param name="port" value="$(arg web_node)" />
+    </node>
 
     <group ns="camera">
         <node name="fore_camera" pkg="rtsp_camera" type="rtsp_camera_node">

--- a/src/phyto_arm/launch/rosbag.launch
+++ b/src/phyto_arm/launch/rosbag.launch
@@ -8,10 +8,12 @@ In the future, we might process inactive rosbags to, for example, correct
 timestamps, or generate reports. See http://wiki.ros.org/rosbag/Cookbook
 -->
 <launch>
-    <arg name="rosbag_prefix" default="/home/hablab/PhytO-ARM/ros/rosbags/phyto-arm" />
+    <arg name="rosbag_dir" default="/data/rosbags/" />
+    <arg name="rosbag_prefix" default="phyto-arm" />
     <arg name="rosbag_size" default="1024" />
     <arg name="rosbag_duration" default="60m" />
 
     <node name="rosbag_record" pkg="rosbag" type="record"
-        args="$(eval 'record --all --exclude /camera/.*|/ifcb/image|/ifcb/in|/ifcb/roi/.*|/rosout_agg --output-prefix ' + arg('rosbag_prefix') + (' --split --size ' + str(arg('rosbag_size')) if arg('rosbag_size') else '') + (' --split --duration ' + str(arg('rosbag_duration')) if arg('rosbag_duration') else '') + ' --publish --lz4')" />
+        args="$(eval 'record --all --exclude /camera/.*|/ifcb/image|/ifcb/in|/ifcb/roi/.*|/rosout_agg --output-prefix ' +  arg('rosbag_dir') + arg('rosbag_prefix') + (' --split --size ' + str(arg('rosbag_size')) if arg('rosbag_size') else '') + (' --split --duration ' + str(arg('rosbag_duration')) if arg('rosbag_duration') else '') + ' --publish --lz4')" />
 </launch>
+

--- a/src/phyto_arm/launch/rosbag.launch
+++ b/src/phyto_arm/launch/rosbag.launch
@@ -8,7 +8,7 @@ In the future, we might process inactive rosbags to, for example, correct
 timestamps, or generate reports. See http://wiki.ros.org/rosbag/Cookbook
 -->
 <launch>
-    <arg name="rosbag_dir" default="/data/rosbags/" />
+    <arg name="rosbag_dir" default="/app/volumes/rosbags/" />
     <arg name="rosbag_prefix" default="phyto-arm" />
     <arg name="rosbag_size" default="1024" />
     <arg name="rosbag_duration" default="60m" />

--- a/src/phyto_arm/src/web_node.py
+++ b/src/phyto_arm/src/web_node.py
@@ -66,7 +66,7 @@ def main():
                                 functools.partial(capture_field_value, name, config['topic_field']))
         else:
             rospy.logerr(f'Config {name} invalid, must have "default" or "environment" set')
-    web.run_app(app, port=8098)
+    web.run_app(app, port=rospy.get_param('~port'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@rgov I want your opinion on this WIP refactor before I finish it.

Today we have accumulated a lot of management layers:
- ROS launch files
- `phyto-arm` Python script
- `screen` within `phyto-arm`
- Docker now wrapping everything
- `tmux` for monitoring Docker containers has become standard in the field
- Shell scripts for starting/stopping Docker and Tmux

If we commit to always using Docker, we can reduce this to:
- ROS launch files
- `phyto-arm` Python script
- Docker

So remove all the `tmux` and `screen` use since Docker persists sessions anyway, use `phyto-arm` to launch ROS directly within containers, and simplify config by also having `phyto-arm` handle mounting of devices/volumes/ports from config automatically, which will eliminate all the gotchas we see in the field where startup fails because Docker-config does not match PA-config.

This also removes the need to launch arms separately - which processes get launched is all setup in the config YAML. Operators will basically only have to touch the YAML going forward.


Thoughts? Not working yet as-is, but I think there's enough there for you to get the approach.