### PR TITLE
Use safer acceleration and torque values

### DIFF
--- a/src/phyto_arm/src/winch_node.py
+++ b/src/phyto_arm/src/winch_node.py
@@ -107,6 +107,8 @@ def velocity_f(target, max_speed, half_speed_dist):
 #
 # Note we must estimate the time to our within-epsilon stopping distance, or
 # else the integral will not converge.
+#
+# FIXME: This does not account for acceleration.
 def estimate_time(v, start, target, epsilon):
     t, _ = quad(
         lambda x: 1/v(x),
@@ -270,9 +272,9 @@ async def move_to_depth(server, goal):
         rpm = rpm_ratio * velocity
 
         set_velocity(
-            velocity=rpm,       # RPM
-            acceleration=1200,  # RPM/s
-            torque=3.0          # rated torque
+            velocity=rpm,     # RPM
+            acceleration=60,  # RPM/s
+            torque=1.00       # nominal load
         )
 
         # Publish feedback about our current progress


### PR DESCRIPTION
The MAC400 is rated for 1.27N•m of continuous torque, but it can briefly reach a peak of 300% of this value. Previously, we were always setting the `T_SOLL` register to allow the motor to reach peak torque.

<img width="728" alt="image" src="https://github.com/user-attachments/assets/b10074e3-8d44-4b6a-88a8-47b3d6c028d3" />

I don't know whether the motor was actually applying peak torque all the time, but this change would limit it to 100% of "nominal load" which I assume is 1.27N•m?

Note that some examples in the manual, such as 2.3.4, show setting torque to 300%...

---

Secondly, the rate of acceleration was previously fixed to 1200 RPM/s. Given the gear ratio and spool circumference in the default config, 1.0 m/s ≈ 5500 RPM. The max speed of 0.02 m/s ≈ 110 RPM. I don't think we really need to accelerate so quickly.

However — these values have not been validated against the mechanical design of the winch system.  I am not a physicist, but allegedly we should calculate acceleration from torque $\tau$ and moment of inertia of the load $J$.

$$\alpha\ \mathrm{RPM/s} = \frac{\tau}{J}\ \times \frac{60}{2\pi}$$

We integrate over the instantaneous velocity function to determine the time limit, and this is only based on the error from our target depth. This is not designed to take into account a ramp up time, so we may hit the time limit more often. We can replace the integration with a numerical simulation to calculate the time limit if this is a problem.