### PR TITLE
Fix Docker container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,17 @@ ARG DEPSCACHE=1
 SHELL ["/usr/bin/bash", "-c"]
 WORKDIR /app
 
+
+# Replace expired GPG key:
+# https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
+ADD https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
+    /tmp/open-robotics.asc
+RUN rm -f /usr/share/keyrings/ros1-latest-archive-keyring.gpg \
+ && gpg --dearmor -o /usr/share/keyrings/ros1-latest-archive-keyring.gpg \
+        /tmp/open-robotics.asc \
+ && rm -f /tmp/open-robotics.asc
+
+
 # Install apt package dependencies
 COPY deps/apt-requirements.txt ./
 RUN apt update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,35 @@ RUN apt update \
  && sed '/^#/d' apt-requirements.txt | xargs apt install -y \
  && rm -rf /var/lib/apt/lists/*
 
+# Update Python setuptools and its dependencies.
+# https://github.com/pypa/setuptools/issues/4478#issuecomment-2235160778
+#
+# We also update to pip 21 which supports PEP 600 and allows us to install
+# wheels with the manylinux_2_17 platform tag. This works around a build error
+# with grpcio.
+#
+# TODO: Revisit this when upgrading beyond Python 3.8 (Ubuntu 20.04).
+RUN python3 -m pip install --upgrade \
+        'pip>=21,<22' \
+        setuptools \
+        importlib_metadata \
+        importlib_resources \
+        more_itertools \
+        ordered-set \
+        packaging \
+        platformdirs \
+        tomli \
+        wheel
+
+# Fix the Cython version to work around a gevent install error.
+# https://github.com/gevent/gevent/issues/2076
+#
+# For some reason related to isolated build environments, this can't go in the
+# python3-requirements.txt. We also have to avoid upgrading to a newer pip.
+RUN python3 -m pip install "Cython<3.1"
+
 # Install Python dependencies
 COPY deps/python3-requirements.txt ./
-RUN python3 -m pip install --upgrade setuptools==69.1.0
 RUN python3 -m pip install -r python3-requirements.txt
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ros:noetic
+
 # Increment DEPSCACHE when there's a known change to deps.rosinstall
 ARG DEPSCACHE=1
-SHELL ["/usr/bin/bash", "-c"]
+
 WORKDIR /app
 
 
@@ -40,12 +41,13 @@ RUN apt update \
 
 # Warm the build directory with pre-built packages that don't change often.
 # This list can be updated according to `catkin build --dry-run phyto_arm`.
-RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
+RUN bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash \
  && stdbuf -o L catkin build \
         ds_core_msgs \
         ds_sensor_msgs \
         ds_util_nodes \
-        rtsp_camera
+        rtsp_camera \
+ "
 
 # Copy package.xml files for local packages
 COPY ./src/aml_ctd/package.xml ./src/aml_ctd/package.xml
@@ -64,8 +66,9 @@ COPY ./src ./src
 COPY ./scripts ./scripts
 
 # Build
-RUN source ./devel/setup.bash \
- && stdbuf -o L catkin build phyto_arm
+RUN bash -c "source devel/setup.bash \
+ && stdbuf -o L catkin build phyto_arm \
+ "
 
 # Copy the launch tool
 ENV DONT_SCREEN=1

--- a/deps/python3-requirements.txt
+++ b/deps/python3-requirements.txt
@@ -7,3 +7,7 @@ scipy==1.10
 tritonclient[all]==2.33.0
 
 git+https://github.com/WHOIGit/pyifcbclient.git#egg=pyifcbclient
+
+# Use an older version of grpcio that's available as a pre-built wheel.
+# TODO: Remove this when we move beyond Python 3.8 (Ubuntu 20.04).
+grpcio<1.71


### PR DESCRIPTION
1. The apt repo key in the official Docker container images expired yesterday, https://github.com/osrf/docker_images/issues/807. There is a fix coming, so I'll just revert this change when it arrives. No need to merge it.

2. Our old Python 3.8 is starting to get creaky:

    1. The newest Cython 3.1 removed support completely for Python 2 syntax, which causes a build failure when building gevent, which is somewhere in the dependency tree of tritonclient.

        A catch is that because pip does more isolated package builds now, even if we pin Cython's version in requirements.txt, gevent builds in parallel with its own Cython 3.1. So instead we have to install Cython 3.0 first, and then the subsequent gevent build will use the installed version.

    2. We had a pinned version of setuptools==69, though I'm not sure why. I wanted to relax this constraint, but it turns out setuptools>=71 doesn't install either. [There's a comment explaining it](https://github.com/pypa/setuptools/issues/4478#issuecomment-2235160778) -- we need to manually install all the dependencies too. Ok, done.

    3. gpcio was failing to build for me. I noticed there is a pre-built wheel available, but because we have pip 21, it doesn't recognize `manylinux_2_17` as a platform tag. This was added in pip 22 with PEP 600 support.

        However, I didn't want to move much beyond pip 22, because I think it adds more build isolation, which might mess up 2(i) again.

Closes #69. <!-- nice -->