### PR TITLE
Run tests when building container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,13 @@ COPY ./scripts ./scripts
 # Build
 RUN bash -c "source devel/setup.bash \
  && stdbuf -o L catkin build phyto_arm \
- "
+ && stdbuf -o L catkin test -- \
+        aml_ctd \
+        ifcb \
+        jvl_motor \
+        phyto_arm \
+        rbr_maestro3_ctd \
+"
 
 # Copy the launch tool
 ENV DONT_SCREEN=1

--- a/src/aml_ctd/CMakeLists.txt
+++ b/src/aml_ctd/CMakeLists.txt
@@ -21,3 +21,7 @@ generate_messages(
 )
 
 catkin_package()
+
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(tests)
+endif()

--- a/src/aml_ctd/package.xml
+++ b/src/aml_ctd/package.xml
@@ -15,6 +15,7 @@
     <author email="vlucke@whoi.edu">Verena Lucke</author>
 
     <buildtool_depend>catkin</buildtool_depend>
+    <test_depend>rosunit</test_depend>
 
     <!-- We use the DsHeader message type -->
     <depend>ds_core_msgs</depend>

--- a/src/phyto_arm/CMakeLists.txt
+++ b/src/phyto_arm/CMakeLists.txt
@@ -38,6 +38,8 @@ generate_messages(
   ds_core_msgs
 )
 
-catkin_add_nosetests(src/tests.py)
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(src/tests.py)
+endif()
 
 catkin_package()


### PR DESCRIPTION
This change runs unit tests in our packages to avoid shipping a broken container.

I decided to limit this to just our packages, rather than all our dependencies, because DS-ROS has some failing test cases in components we do not use.