### PR TITLE
Automatic retry and recovery if IFCB connection is lost

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -195,6 +195,9 @@ arm_ifcb:
 
 arm_chanos: #optional
     tasks:
+        # Pause if IFCB disconnects. If False and IFCB disconnects, will shutdown and alert.
+        pause_tasks_until_connected: False #optional
+
         dwell_time: 60 # seconds
         # For continuous movements (no steps), a speed can be specified.
         continuous_speed: 0.005

--- a/deps/python3-requirements.txt
+++ b/deps/python3-requirements.txt
@@ -1,4 +1,4 @@
-# Cache buster: 1 -- increment to force rebuild of the container image layer
+# Cache buster: 2 -- increment to force rebuild of the container image layer
 
 aiohttp==3.10.11
 pyModbusTCP==0.1.8

--- a/src/ifcb/src/ifcb/node.py
+++ b/src/ifcb/src/ifcb/node.py
@@ -4,6 +4,7 @@ import json
 import os
 import struct
 import threading
+import time
 
 import rospy
 
@@ -15,23 +16,30 @@ from ds_core_msgs.msg import RawData
 from foxglove_msgs.msg import ImageMarkerArray
 from geometry_msgs.msg import Point
 from sensor_msgs.msg import CompressedImage
-from std_msgs.msg import ColorRGBA
+from std_msgs.msg import ColorRGBA, Bool
 from visualization_msgs.msg import ImageMarker
 
 from .instrumentation import instrument_routine
 
 
 ifcb_ready = threading.Event()
+connection_lost = threading.Event()
+ifcb_client = None  # Global client managed by connection manager
+client_lock = threading.Lock()  # Protect client access
 
 # Apologies for the horrible naming. This is the ROS service handler that
 # invokes send_command() and returns an empty response.
-def do_command(client, pub, req):
-    send_command(client, pub, req.command)
+def do_command(pub, req):
+    if connection_lost.is_set():
+        rospy.logwarn(f'Cannot send command "{req.command}": IFCB is not connected')
+        return srv.CommandResponse()  # Commands don't return success/failure
+
+    send_command(pub, req.command)
     return srv.CommandResponse()
 
 
 # The ROS service handler that runs a routine, optionally with instrumentation
-def do_runroutine(client, pub, req):
+def do_runroutine(pub, req):
     # XXX
     # We always use the 'interactive:start' command instead of 'routine' because
     # the latter does not (as of Apr 21, 2022) provide any feedback when the
@@ -43,15 +51,19 @@ def do_runroutine(client, pub, req):
     # This means that the routines *must* be written to disk at the expected
     # location.
 
+    if connection_lost.is_set():
+        rospy.logwarn(f'Cannot run routine "{req.routine}": IFCB is not connected')
+        return srv.RunRoutineResponse(success=False)
+
     # Deny path traversal
     if '/' in req.routine:
         return srv.RunRoutineResponse(success=False)
 
     # Check for beads routines
     if req.routine == 'beads':
-        send_command(client, pub, f'daq:setdatafolder:{rospy.get_param("~data_dir")}/beads')
+        send_command(pub, f'daq:setdatafolder:{rospy.get_param("~data_dir")}/beads')
     else:
-        send_command(client, pub, f'daq:setdatafolder:{rospy.get_param("~data_dir")}')
+        send_command(pub, f'daq:setdatafolder:{rospy.get_param("~data_dir")}')
 
     # Attempt to load the file
     path = os.path.join(rospy.get_param('~routines_dir'), f'{req.routine}.json')
@@ -68,16 +80,28 @@ def do_runroutine(client, pub, req):
 
     # Encode and send the routine
     encoded = json.dumps(routine, separators=(',', ':'))  # less whitespace
-    send_command(client, pub, f'interactive:load:{encoded}')
-    send_command(client, pub, 'interactive:start')
+    send_command(pub, f'interactive:load:{encoded}')
+    send_command(pub, 'interactive:start')
 
     return srv.RunRoutineResponse(success=True)
 
 
 # Send a command to the IFCB host and publish it to ROS
-def send_command(client, pub, command):
+def send_command(pub, command):
     # Wait for the IFCB to be ready; this prevents sending a command too early
     ifcb_ready.wait()
+
+    # Check if we're connected before trying to send
+    if connection_lost.is_set():
+        rospy.logwarn(f'IFCB disconnected, cannot send command: {command}')
+        return
+
+    # Get client safely
+    with client_lock:
+        client = ifcb_client
+        if client is None:
+            rospy.logwarn(f'No IFCB client available, cannot send command: {command}')
+            return
 
     # Construct the message we are going to publish
     msg = RawData()
@@ -85,12 +109,16 @@ def send_command(client, pub, command):
     msg.data_direction = RawData.DATA_OUT
     msg.data = command.encode()
 
-    # Send the command
-    client.relay_message_to_host(command)
-
-    # Publish the message after sending it, so that the timestamp is more
-    # accurate.
-    pub.publish(msg)
+    # Send the command with error handling
+    try:
+        client.relay_message_to_host(command)
+        # Publish the message after sending it, so that the timestamp is more accurate
+        pub.publish(msg)
+    except Exception as e:
+        rospy.logerr(f'Failed to send command "{command}": {e}')
+        # Mark connection as lost to trigger reconnection
+        connection_lost.set()
+        ifcb_ready.clear()
 
 
 # Publish incoming "raw" messages from the IFCB as ROS messages
@@ -107,15 +135,25 @@ def on_any_message(pub, data):
 
 
 # Callback for the "startedAsClient" message from the IFCB
-def on_started(client, pub, *args, **kwargs):
+def on_started(*args, **kwargs):
     rospy.loginfo('Established connection to the IFCB')
 
-    # Allow any queued commands to proceed now that the IFCB is available
+    # Clear the connection lost flag and allow any queued commands to proceed
+    connection_lost.clear()
     ifcb_ready.set()
 
+# Callback for when connection is lost
+def on_connection_lost(status_pub):
+    rospy.logwarn('IFCB connection lost, attempting to reconnect...')
+    connection_lost.set()
+    ifcb_ready.clear()
+
+    # Publish connection status
+    status_pub.publish(Bool(data=False))
+
 # Reset the data folder to the configured data directory
-def on_interactive_stopped(client, pub, *_):
-    send_command(client, pub, f'daq:setdatafolder:{rospy.get_param("~data_dir")}')
+def on_interactive_stopped(pub, *_):
+    send_command(pub, f'daq:setdatafolder:{rospy.get_param("~data_dir")}')
 
 def on_triggerimage(pub, _, image):
     # The image data should be in PNG format, which is an allowed ROS image type
@@ -173,6 +211,81 @@ def on_triggerrois(roi_pub, mkr_pub, _, rois, *, timestamp=None):
     mkr_pub.publish(markers)
 
 
+# Manages IFCB client creation, connection, and callback setup with automatic retry on failure.
+def connection_manager(publishers, retry_interval=5, max_retry_interval=60):
+    global ifcb_client
+    current_retry_interval = retry_interval
+
+    while not rospy.is_shutdown():
+        try:
+            if connection_lost.is_set() or not ifcb_ready.is_set():
+                rospy.loginfo('Creating IFCB client and attempting connection...')
+
+                # Create the client
+                try:
+                    client = IFCBClient(
+                        f'ws://{rospy.get_param("~address")}'\
+                            f':{rospy.get_param("~port", 8092)}/ifcbHub',
+                        rospy.get_param('~serial'),
+                    )
+                except Exception as client_error:
+                    raise ConnectionError(f"Failed to create IFCB client: {client_error}")
+
+                # Set up callbacks before connecting
+                client.hub_connection.on('messageRelayed',
+                    functools.partial(on_any_message, publishers['rx']))
+                client.hub_connection.on('startedAsClient', on_started)
+                client.on(('triggerimage',),
+                          functools.partial(on_triggerimage, publishers['img']))
+                client.on(('triggercontent',),
+                          functools.partial(on_triggercontent, publishers['roi'], publishers['mkr']))
+                client.on(('triggerrois',),
+                          functools.partial(on_triggerrois, publishers['roi'], publishers['mkr']))
+                client.on(('valuechanged','interactive','stopped',),
+                          functools.partial(on_interactive_stopped, publishers['tx']))
+
+                # Try to connect
+                try:
+                    client.connect()
+                except Exception as connect_error:
+                    raise ConnectionError(f"Failed to initiate connection: {connect_error}")
+
+                # Wait a bit to see if connection establishes
+                time.sleep(2)
+
+                # Check if we got the startedAsClient callback
+                if ifcb_ready.is_set() and not connection_lost.is_set():
+                    rospy.loginfo('IFCB connection successful')
+                    # Store the working client globally
+                    with client_lock:
+                        ifcb_client = client
+                    # Publish connection status after client is set
+                    publishers['status'].publish(Bool(data=True))
+                    current_retry_interval = retry_interval  # Reset retry interval on success
+                else:
+                    raise ConnectionError("Connection did not establish properly")
+
+            # Connection monitoring - check every few seconds
+            time.sleep(5)
+
+        except Exception:
+            # Clear the failed client
+            with client_lock:
+                ifcb_client = None
+            connection_lost.set()
+            ifcb_ready.clear()
+
+            # Publish disconnected status
+            on_connection_lost(publishers['status'])
+
+            # Exponential backoff with jitter
+            rospy.loginfo(f'Retrying IFCB connection in {current_retry_interval} seconds...')
+            time.sleep(current_retry_interval)
+
+            # Increase retry interval, but cap it at max_retry_interval
+            current_retry_interval = min(current_retry_interval * 1.5, max_retry_interval)
+
+
 def main():
     rospy.init_node('ifcb', anonymous=True)
 
@@ -185,51 +298,47 @@ def main():
     roi_pub = rospy.Publisher('~roi/image', CompressedImage, queue_size=5)
     mkr_pub = rospy.Publisher('~roi/markers', ImageMarkerArray, queue_size=5)
 
-    # Create an IFCB websocket API client
-    client = IFCBClient(
-        f'ws://{rospy.get_param("~address")}'\
-            f':{rospy.get_param("~port", 8092)}/ifcbHub',
-        rospy.get_param('~serial'),
-    )
+    # Publisher for connection status (latched so new subscribers get current state)
+    status_pub = rospy.Publisher('~connected', Bool, queue_size=1, latch=True)
 
-    # Publish all messages that come in, prior to being parsed.
-    # Note: This relies on internal implementation details of pyifcbclient.
-    client.hub_connection.on('messageRelayed',
-        functools.partial(on_any_message, rx_pub))
-
-    # Set up a callback for when the connection starts.
-    # Note: This too relies on internal implementation details of pyifcbclient.
-    client.hub_connection.on('startedAsClient',
-        functools.partial(on_started, client, tx_pub))
-
-    # Set up callbacks for trigger images and ROIs
-    client.on(('triggerimage',),
-              functools.partial(on_triggerimage, img_pub))
-    client.on(('triggercontent',),
-              functools.partial(on_triggercontent, roi_pub, mkr_pub))
-    client.on(('triggerrois',),
-              functools.partial(on_triggerrois, roi_pub, mkr_pub))
-
-    # Set up callbacks for datafolder switching
-    client.on(('valuechanged','interactive','stopped',),
-              functools.partial(on_interactive_stopped, client, tx_pub))
+    # Bundle publishers for the connection manager
+    publishers = {
+        'rx': rx_pub,
+        'tx': tx_pub,
+        'img': img_pub,
+        'roi': roi_pub,
+        'mkr': mkr_pub,
+        'status': status_pub
+    }
 
     # Create a ROS service for sending commands
     rospy.Service(
         '~command',
         srv.Command,
-        functools.partial(do_command, client, tx_pub),
+        functools.partial(do_command, tx_pub),
     )
 
     # Create a ROS service for running routines
     rospy.Service(
         '~routine',
         srv.RunRoutine,
-        functools.partial(do_runroutine, client, tx_pub),
+        functools.partial(do_runroutine, tx_pub),
     )
 
-    # Connect the client
-    client.connect()
+    # Publish initial disconnected status (will be updated when connection succeeds)
+    status_pub.publish(Bool(data=False))
+
+    # Start connection manager in a separate thread
+    # It will handle client creation, connection, and callback setup
+    connection_lost.set()  # Start in disconnected state to trigger initial connection
+    connection_thread = threading.Thread(
+        target=connection_manager,
+        args=(publishers,),
+        daemon=True
+    )
+    connection_thread.start()
+
+    rospy.loginfo('IFCB node started, attempting connection to IFCB...')
 
     # Keep the program alive while other threads work
     rospy.spin()

--- a/src/ifcb/src/ifcb/node.py
+++ b/src/ifcb/src/ifcb/node.py
@@ -229,7 +229,7 @@ def connection_manager(publishers, retry_interval=5, max_retry_interval=60):
             else:
                 raise ConnectionError("No ready message received")
 
-        except ConnectionError:
+        except ConnectionError as connect_error:
             rospy.logwarn(f"Unable to establish connection to IFCB: {connect_error}")
 
             # Exponential backoff with jitter

--- a/src/ifcb/src/ifcb/node.py
+++ b/src/ifcb/src/ifcb/node.py
@@ -221,10 +221,11 @@ def connection_manager(publishers, retry_interval=5, max_retry_interval=60):
     current_retry_interval = retry_interval
 
     while not rospy.is_shutdown():
-        if connection_lost or not ifcb_ready.is_set():
-            rospy.loginfo('Creating IFCB client and attempting connection...')
+        if not connection_lost and ifcb_ready.is_set():
+            rospy.sleep(5)
             continue
         try:
+            rospy.loginfo('Creating IFCB client and attempting connection...')
             try:
                 client = IFCBClient(
                     f'ws://{rospy.get_param("~address")}'\
@@ -267,9 +268,6 @@ def connection_manager(publishers, retry_interval=5, max_retry_interval=60):
                 current_retry_interval = retry_interval  # Reset retry interval on success
             else:
                 raise ConnectionError("Connection did not establish properly")
-
-            # Connection monitoring - check every few seconds
-            time.sleep(5)
 
         except Exception as connect_error:
             rospy.logwarn(f"Unable to establish connection to IFCB: {connect_error}")

--- a/src/ifcb/src/ifcb/node.py
+++ b/src/ifcb/src/ifcb/node.py
@@ -243,7 +243,7 @@ def connection_manager(publishers, retry_interval=5, max_retry_interval=60):
                 raise ConnectionError(f"Failed to create IFCB client: {client_error}")
 
             # Set up callbacks before connecting
-            client.on_started('startedAsClient', on_started)
+            client.on_started(on_started)
             client.on_reconnect(
                         functools.partial(on_connection_lost, publishers['status']))
             client.on_any_message('messageRelayed',

--- a/src/ifcb/src/ifcb/node.py
+++ b/src/ifcb/src/ifcb/node.py
@@ -121,7 +121,7 @@ def on_any_message(pub, data):
 
 # Callback for the "startedAsClient" message from the IFCB
 def on_started(*args, **kwargs):
-    rospy.loginfo('Established connection to the IFCB')
+    rospy.logwarn('Established connection to the IFCB')
     ifcb_ready.set()
 
 # Callback for when connection is lost

--- a/src/ifcb/src/ifcb/node.py
+++ b/src/ifcb/src/ifcb/node.py
@@ -246,7 +246,7 @@ def connection_manager(publishers, retry_interval=5, max_retry_interval=60):
             client.on_started(on_started)
             client.on_reconnect(
                         functools.partial(on_connection_lost, publishers['status']))
-            client.on_any_message('messageRelayed',
+            client.on_any_message(
                         functools.partial(on_any_message,publishers['rx']))
             client.on(('triggerimage',),
                         functools.partial(on_triggerimage, publishers['img']))

--- a/src/ifcb/src/ifcb/node.py
+++ b/src/ifcb/src/ifcb/node.py
@@ -241,6 +241,8 @@ def connection_manager(publishers, retry_interval=5, max_retry_interval=60):
 
 
 def main():
+    global ifcb_client
+
     rospy.init_node('ifcb', anonymous=True)
 
     # Publishers for raw messages coming in and out of the IFCB
@@ -268,7 +270,7 @@ def main():
     # Create and configure IFCB client once
     rospy.loginfo('Creating IFCB client...')
     try:
-        client = IFCBClient(
+        ifcb_client = IFCBClient(
             f'ws://{rospy.get_param("~address")}'\
                 f':{rospy.get_param("~port", 8092)}/ifcbHub',
             rospy.get_param('~serial'),
@@ -278,18 +280,18 @@ def main():
         return
 
     # Set up callbacks once
-    client.on_started(on_started)
-    client.on_reconnect(
+    ifcb_client.on_started(on_started)
+    ifcb_client.on_reconnect(
                 functools.partial(on_connection_lost, publishers['status']))
-    client.on_any_message(
+    ifcb_client.on_any_message(
                 functools.partial(on_any_message,publishers['rx']))
-    client.on(('triggerimage',),
+    ifcb_client.on(('triggerimage',),
                 functools.partial(on_triggerimage, publishers['img']))
-    client.on(('triggercontent',),
+    ifcb_client.on(('triggercontent',),
                 functools.partial(on_triggercontent, publishers['roi'], publishers['mkr']))
-    client.on(('triggerrois',),
+    ifcb_client.on(('triggerrois',),
                 functools.partial(on_triggerrois, publishers['roi'], publishers['mkr']))
-    client.on(('valuechanged','interactive','stopped',),
+    ifcb_client.on(('valuechanged','interactive','stopped',),
                 functools.partial(on_interactive_stopped, publishers['tx']))
 
     # Create a ROS service for sending commands

--- a/src/ifcb/srv/Command.srv
+++ b/src/ifcb/srv/Command.srv
@@ -4,3 +4,5 @@
 string command
 
 ---
+
+bool success

--- a/src/phyto_arm/src/arm_ifcb.py
+++ b/src/phyto_arm/src/arm_ifcb.py
@@ -38,7 +38,7 @@ class ArmIFCB(ArmBase):
     #  - speed: the speed to move at (optional, will use config max if not provided)
     def get_next_task(self, last_task):
         # Check if we should pause tasks when IFCB is disconnected
-        pause_on_disconnect = rospy.get_param('tasks/ifcb/pause_tasks_until_connected', False)
+        pause_on_disconnect = rospy.get_param('tasks/pause_tasks_until_connected', False)
         if pause_on_disconnect and not self.ifcb_connected:
             rospy.logwarn('IFCB is disconnected. Waiting for connection...')
             return Task('await_ifcb_connection', await_ifcb_connection)

--- a/src/phyto_arm/src/arm_ifcb.py
+++ b/src/phyto_arm/src/arm_ifcb.py
@@ -10,6 +10,7 @@ import rospy
 
 from arm_base import ArmBase, Task
 from phyto_arm.msg import DepthProfile, RunIFCBGoal, RunIFCBAction
+from std_msgs.msg import Bool
 
 
 class ArmIFCB(ArmBase):
@@ -26,6 +27,9 @@ class ArmIFCB(ArmBase):
     last_cart_debub_time = None
     last_bead_time = None
 
+    ifcb_connected = False
+    ifcb_connection_event = Event()
+
     # Primary method for determining the next task to execute
     # Each Task object takes:
     #  - name: a string identifying the task
@@ -36,13 +40,20 @@ class ArmIFCB(ArmBase):
         if not rospy.get_param('winch_enabled'):
             return Task('no_winch', handle_nowinch)
 
+        # Check if we should pause tasks when IFCB is disconnected
+        pause_on_disconnect = rospy.get_param('tasks/ifcb/pause_tasks_until_connected', False)
+        if pause_on_disconnect and not self.ifcb_connected:
+            rospy.logwarn('IFCB is disconnected. Waiting for connection...')
+            return Task('await_ifcb_connection', await_ifcb_connection)
+
         # If close to scheduled wiz time, prioritize first
         if its_wiz_time():
             wiz_depth = compute_wiz_depth(self.profiler_peak_depth)
             return Task('wiz_probe', lambda _: await_wiz_probe(self.start_next_task), wiz_depth)
 
-        # Othrwise, start off at min
-        if last_task is None or last_task.name in ['scheduled_depth', 'profiler_peak_depth', 'wiz_probe']:
+        # Otherwise, start off at min
+        preupcast_tasks = ['scheduled_depth', 'profiler_peak_depth', 'wiz_probe', 'await_ifcb_connection']
+        if last_task is None or last_task.name in preupcast_tasks:
             return Task('upcast', self.start_next_task, rospy.get_param('winch/range/min'))
 
         # Then perform a downcast to get a full profile
@@ -75,6 +86,25 @@ def on_profile_msg(msg):
     arm.profile_activity.set()
     arm.profile_activity.clear()
 
+
+def on_ifcb_connection_status(msg):
+    arm.ifcb_connected = msg.data
+    if arm.ifcb_connected:
+        rospy.loginfo('IFCB connection established')
+        arm.ifcb_connection_event.set()
+        arm.ifcb_connection_event.clear()
+    else:
+        rospy.logwarn('IFCB connection lost')
+
+
+def await_ifcb_connection():
+    while not arm.ifcb_connected and not rospy.is_shutdown():
+        rospy.loginfo('Waiting for IFCB connection...')
+        arm.ifcb_connection_event.wait(30)
+
+    if arm.ifcb_connected:
+        rospy.loginfo('IFCB connection restored, resuming tasks')
+        arm.start_next_task()
 
 # Convert HH:MM to a rospy.Time datetime. Take into account the current time,
 # pushing the requested time to the next day if it's already passed.
@@ -246,6 +276,9 @@ def main():
 
     # Subscribe to profiler messages that follow each transit
     rospy.Subscriber('profiler', DepthProfile, on_profile_msg)
+
+    # Subscribe to IFCB connection status
+    rospy.Subscriber('/ifcb/connected', Bool, on_ifcb_connection_status)
 
     # Setup action client for running IFCB
     ifcb_runner = actionlib.SimpleActionClient('ifcb_runner/sample', RunIFCBAction)

--- a/src/phyto_arm/src/arm_ifcb.py
+++ b/src/phyto_arm/src/arm_ifcb.py
@@ -37,14 +37,14 @@ class ArmIFCB(ArmBase):
     #  - depth: the depth to move to (optional, won't move if not provided)
     #  - speed: the speed to move at (optional, will use config max if not provided)
     def get_next_task(self, last_task):
-        if not rospy.get_param('winch_enabled'):
-            return Task('no_winch', handle_nowinch)
-
         # Check if we should pause tasks when IFCB is disconnected
         pause_on_disconnect = rospy.get_param('tasks/ifcb/pause_tasks_until_connected', False)
         if pause_on_disconnect and not self.ifcb_connected:
             rospy.logwarn('IFCB is disconnected. Waiting for connection...')
             return Task('await_ifcb_connection', await_ifcb_connection)
+
+        if not rospy.get_param('winch_enabled'):
+            return Task('no_winch', handle_nowinch)
 
         # If close to scheduled wiz time, prioritize first
         if its_wiz_time():


### PR DESCRIPTION
Harvested from Oleander deployment. Used because IFCB is not always on, has to be shutdown sometimes to prevent overheating. We use the `ifcb/connected` topic to determine whether it is safe to start sending commands.