### PR TITLE
Filter ROI images out of triggercontent messages

### DIFF
--- a/src/ifcb/src/ifcb/logfilter_node.py
+++ b/src/ifcb/src/ifcb/logfilter_node.py
@@ -16,6 +16,16 @@ def on_message(pub, msg):
         for i in range(4, len(parts), 3):
             parts[i] = b'<omitted>'
         msg.data = b':'.join(parts)
+    elif msg.data.startswith(b'triggercontent:'):
+        parts = msg.data.split(b':')
+        try:
+            rois_idx = parts.index(b'rois')
+            count = int(parts[rois_idx + 1])
+            for j in range(count):
+                parts[rois_idx + 1 + 3 * (j + 1)] = b'<omitted>'
+        except (ValueError, IndexError):
+            pass
+        msg.data = b':'.join(parts)
     elif msg.data.startswith(b'file:chunk:'):
         parts = msg.data.split(b':', maxsplit=4)
         parts[-1] = b'<omitted>'


### PR DESCRIPTION
The `triggercontent` messages from the IFCB contain ROI images:

```
triggercontent:...:rois:1:1060:358:iVBORw0KGgoAAAANSUhEUgA...
```

We are missing `triggercontent:` in our  IFCB filtered log output node, causing ROS bags to contain image data we try to avoid, which inflates the file size and burns our data quota.

To test, I processed the file `phyto-arm_plusultra_2025-08-08-02-25-29_0.bag`. Correctly filtering these messages would remove about 21 MB of uncompressed data. The bag compression complicates analysis of how much this saves on disk, I would estimate this is taking up about half of the bag files.

Fixes #102.