### PR TITLE
Use install space instead of devel

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,23 +2,32 @@ name: Build container image
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # For multi-platform builds
       # https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
       - name: Initialize
         id: init
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           # Determine whether to push to Docker Hub based on the event type
-          case "${{ github.event_name }}" in
+          case "$EVENT_NAME" in
             push)
               DOCKER_PUSH=true ;;
             *)
@@ -26,7 +35,7 @@ jobs:
           esac
 
           # Map git ref branch or tag name to Docker tag version
-          case "${{ github.ref }}" in
+          case "$GIT_REF" in
             # Do not push upstream branches and tags to Docker Hub
             refs/heads/upstream/*|refs/tags/upstream/*)
               DOCKER_PUSH=false ;;
@@ -36,13 +45,13 @@ jobs:
               DOCKER_PUSH=false ;;
           esac
 
-          echo ::set-output name=docker_push::$DOCKER_PUSH
-          echo ::set-output name=docker_repo::whoi/$(basename "${{ github.repository }}" | tr A-Z a-z)
-          echo ::set-output name=docker_platforms::linux/amd64,linux/arm64
+          echo "docker_push=$DOCKER_PUSH" >> "$GITHUB_OUTPUT"
+          echo "docker_repo=whoi/$(basename "$REPOSITORY" | tr A-Z a-z)" >> "$GITHUB_OUTPUT"
+          echo "docker_platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.init.outputs.docker_repo }}
           tags: |
@@ -54,54 +63,18 @@ jobs:
 
       - name: Log into registry
         if: steps.init.outputs.docker_push == 'true'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      # Enable Docker layer caching in the GitHub Actions cache.
-      #
-      # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-multi-buildx
-
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
+          context: .
           platforms: ${{ steps.init.outputs.docker_platforms }}
-          push: false
+          push: ${{ steps.init.outputs.docker_push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=local,src=/tmp/.buildx-cache
-            type=registry,ref=${{ steps.init.outputs.docker_repo }}:buildcache
-          cache-to: |
-            type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      # Because `docker buildx build` cannot have multiple cache export targets
-      # yet, we build and push separately.
-      #
-      # During the build step (above), we update the GitHub Actions cache. Then
-      # we use this cache to rebuild, pushing both the image and the cache up to
-      # the registry.
-      - name: Push
-        if: steps.init.outputs.docker_push == 'true'
-        uses: docker/build-push-action@v2
-        with:
-          platforms: ${{ steps.init.outputs.docker_platforms }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=local,src=/tmp/.buildx-cache-new
-          cache-to: |
-            type=registry,ref=${{ steps.init.outputs.docker_repo }}:buildcache,mode=max
-
-      - name: Update cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,75 @@
-FROM ros:noetic AS common-deps
+# ==============================================================================
+# Base stage without any sources
+FROM ros:noetic AS base
 
 WORKDIR /app
 
-
-# Install apt package dependencies
-COPY deps/apt-requirements.txt ./
-RUN apt update \
- && sed '/^#/d' apt-requirements.txt | xargs apt install -y \
+# Base dependencies required to bootstrap a build environment. Package-specific
+# dependencies should be added to package.xml and resolved with rosdep.
+RUN apt update && apt install -y \
+    build-essential \
+    git \
+    python3-catkin-tools \
+    python3-pip \
+    python3-rosdep \
+    python3-vcstool \
  && rm -rf /var/lib/apt/lists/*
+
+RUN rosdep update --rosdistro=${ROS_DISTRO}
+
+
+
+# ==============================================================================
+# Base stage with third-party sources from VCS, but without local sources.
+# We have to separate these because we don't want them in the runtime image.
+FROM base AS base-with-vcs-sources
+
+# Copy and import VCS dependencies
+COPY deps/deps.rosinstall ./deps/
+RUN mkdir -p src \
+ && vcs import src < deps/deps.rosinstall
+
+
+
+# ==============================================================================
+# Stage for dumping rosdep requirements from all ROS packages. This is usually
+# skipped unless we specifically want to regenerate the dependencies file.
+FROM base-with-vcs-sources AS generate-rosdep-requirements
+
+# Copy local source packages (we really only need package.xml files).
+COPY src/ src/
+
+# Generate rosdep requirements list
+RUN rosdep install --from-paths src/ --ignore-src \
+        --rosdistro=${ROS_DISTRO} --simulate \
+        | grep 'apt-get install' \
+        | sed 's/.*apt-get install //' \
+        | tr ' ' '\n' \
+        | grep -v '^-' \
+        | sort -u > /tmp/apt-rosdep-requirements.txt
+
+# When we build only this stage, at runtime we just print the list of
+# dependencies. This gets overridden in the 'full' build.
+CMD ["cat", "/tmp/apt-rosdep-requirements.txt"]
+
+
+
+# ==============================================================================
+# Intermediate stage where we install all dependencies
+FROM base-with-vcs-sources AS with-deps-without-local-sources
+
+# Install rosdep apt dependencies from pre-generated file
+COPY deps/apt-rosdep-requirements.txt ./deps/
+
+RUN apt update \
+ && apt install -y $(sed 's/#.*//' deps/apt-rosdep-requirements.txt) \
+ && rm -rf /var/lib/apt/lists/*
+
+# Verify all dependencies are now installed
+RUN rosdep check --from-paths src/ --ignore-src || \
+    (echo "ERROR: Missing dependencies!" \
+     && echo "Run: ./scripts/generate-rosdep-requirements.sh" \
+     && exit 1)
 
 
 # Update Python setuptools and its dependencies.
@@ -37,7 +99,6 @@ RUN python3 -m pip install --upgrade \
 # ROS 2 / colcon / Ubuntu 24.04, we don't need this workaround anymore.
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 
-
 # Fix the Cython version to work around a gevent install error.
 # https://github.com/gevent/gevent/issues/2076
 #
@@ -46,59 +107,39 @@ ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 RUN python3 -m pip install "Cython<3.1"
 
 # Install Python dependencies
-COPY deps/python3-requirements.txt ./
-RUN python3 -m pip install --ignore-installed -r python3-requirements.txt
+COPY deps/python3-requirements.txt ./deps/
+RUN python3 -m pip install --ignore-installed -r deps/python3-requirements.txt
 
 
 
 ################################################################################
+# Now, with all dependencies installed, we can build the ROS packages into the
+# install space.
+FROM with-deps-without-local-sources AS builder
 
-# Continue from common-deps for building all ROS packages
-FROM common-deps AS builder
-
-# Clone third-party dependencies from VCS
-COPY deps/deps.rosinstall ./
-RUN echo Installing ROS dependencies \
- && mkdir ./src \
- && vcs import src < deps.rosinstall
-
-# Configure catkin to use install space instead of devel space
-RUN bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash \
- && catkin config --install \
- "
-
-# Install dependencies declared in package.xml files
-RUN apt update \
- && rosdep install --default-yes --from-paths ./src --ignore-src \
- && rm -rf /var/lib/apt/lists/*
-
-# Warm the build directory with pre-built packages that don't change often.
+# Initialize the catkin workspace and pre-build the third-party packages.
 # This list can be updated according to `catkin build --dry-run phyto_arm`.
 RUN bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash \
- && stdbuf -o L catkin build \
+ && catkin config --install \
+ && catkin build \
+        ds_asio \
+        ds_base \
         ds_core_msgs \
+        ds_core_msgs \
+        ds_nmea_msgs \
+        ds_param \
+        ds_sensor_msgs \
         ds_sensor_msgs \
         ds_util_nodes \
+        ds_util_nodes \
         rtsp_camera \
+        rtsp_camera \
+        triton_classifier \
  "
 
-# Copy package.xml files for local packages
-COPY ./src/aml_ctd/package.xml ./src/aml_ctd/package.xml
-COPY ./src/dli_power_switch/package.xml ./src/dli_power_switch/package.xml
-COPY ./src/ifcb/package.xml ./src/ifcb/package.xml
-COPY ./src/jvl_motor/package.xml ./src/jvl_motor/package.xml
-COPY ./src/phyto_arm/package.xml ./src/phyto_arm/package.xml
-COPY ./src/rbr_maestro3_ctd/package.xml ./src/rbr_maestro3_ctd/package.xml
+# Build and test local packages
+COPY src/ src/
 
-# Install new rosdep dependencies declared in the above package.xml files
-RUN apt update \
- && rosdep install --default-yes --from-paths ./src --ignore-src \
- && rm -rf /var/lib/apt/lists/*
-
-# Copy the rest of the source
-COPY ./src ./src
-
-# Build
 RUN bash -c "source install/setup.bash \
  && stdbuf -o L catkin build phyto_arm \
  && stdbuf -o L catkin test -- \
@@ -113,22 +154,8 @@ RUN bash -c "source install/setup.bash \
 
 
 ################################################################################
-
-# Revert back to common-deps for the runtime image
-FROM common-deps AS runtime
-
-# Copy the ROS install space from builder
-COPY --from=builder /app/install /app/install
-
-
-# Install runtime dependencies declared in package.xml files.
-#
-# Unfortunately this layer does not cache well and will be invalidated whenever
-# the builder stage changes.
-RUN apt update \
- && rosdep install --default-yes --from-paths ./install --ignore-src \
-        --dependency-types=exec \
- && rm -rf /var/lib/apt/lists/*
+# Finally, we create a runtime stage with only installed packages
+FROM with-deps-without-local-sources AS runtime
 
 
 # Install the ROS Launchpad management server
@@ -138,11 +165,13 @@ RUN mkdir -p /launchpad \
  && python3 -m pip install --ignore-installed -r /launchpad/requirements.txt
 
 
-# Copy the launch tools and server files
+# Install the launch tools and server files
 COPY ./phyto-arm ./phyto-arm
+
 
 # Expose web interface port
 EXPOSE 8080
+
 
 # Source ROS environment automatically for all bash sessions
 RUN echo 'source /app/install/setup.bash' >> /etc/bash.bashrc
@@ -151,3 +180,7 @@ ENTRYPOINT ["/bin/bash", "-c", "source /app/install/setup.bash && exec \"$@\"", 
 
 # Default command runs the server with ROS environment sourced
 CMD ["/bin/bash", "-c", "cd /launchpad && python3 server.py --package phyto_arm --config /app/mounted_config.yaml /app/configs/example.yaml"]
+
+
+# Finally, copy the ROS install space from builder
+COPY --from=builder /app/install /app/install

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt update \
  && sed '/^#/d' apt-requirements.txt | xargs apt install -y \
  && rm -rf /var/lib/apt/lists/*
 
+
 # Update Python setuptools and its dependencies.
 # https://github.com/pypa/setuptools/issues/4478#issuecomment-2235160778
 #
@@ -28,6 +29,14 @@ RUN python3 -m pip install --upgrade \
         platformdirs \
         tomli \
         wheel
+
+# Force setuptools to use stdlib distutils. This is required to be able to use
+# `catkin install` with our newer setuptools, which provides its own distutils.
+#
+# TODO: distutils was removed from the stdlib in Python 3.12. When we migrate to
+# ROS 2 / colcon / Ubuntu 24.04, we don't need this workaround anymore.
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
+
 
 # Fix the Cython version to work around a gevent install error.
 # https://github.com/gevent/gevent/issues/2076

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,14 +169,21 @@ RUN mkdir -p /launchpad \
 COPY ./phyto-arm ./phyto-arm
 
 
+# Create hot-reload workspace directory structure
+RUN mkdir -p /hot/ros1/src
+
+
 # Expose web interface port
 EXPOSE 8080
 
 
 # Source ROS environment automatically for all bash sessions
-RUN echo 'source /app/install/setup.bash' >> /etc/bash.bashrc
+RUN echo 'source /app/install/setup.bash' >> /etc/bash.bashrc \
+ && echo 'if [ -f /hot/ros1/devel/setup.bash ]; then source /hot/ros1/devel/setup.bash; fi' >> /etc/bash.bashrc
 
-ENTRYPOINT ["/bin/bash", "-c", "source /app/install/setup.bash && exec \"$@\"", "--"]
+# Install the entrypoint script.
+# The entrypoint path is inherited from the ROS base image.
+COPY ros_entrypoint.sh /ros_entrypoint.sh
 
 # Default command runs the server with ROS environment sourced
 CMD ["/bin/bash", "-c", "cd /launchpad && python3 server.py --package phyto_arm --config /app/mounted_config.yaml /app/configs/example.yaml"]

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ docker exec -it phyto-arm start mock_arm_chanos /configs/config.yaml
 
 To run unit tests, execute
 ```bash
-docker run -it --rm whoi/phyto-arm:latest /bin/bash -c "source devel/setup.bash && catkin test phyto_arm"
+docker run -it --rm whoi/phyto-arm:latest /bin/bash -c "source install/setup.bash && catkin test phyto_arm"
 ```
 
 ## Configuration
@@ -200,7 +200,7 @@ When running in a container, ensure the config YAML refers to the Docker host's 
 
 The entries in the config file are loaded into the ROS [Parameter Server][]. Some parameters can be dynamically changed while the nodes are running:
 
-    $ source devel/setup.bash
+    $ source install/setup.bash
     $ rosparam get /conductor/schedule/every
     60
     $ rosparam set /profiler/data_topic /ctd/aml/port3/chloroblue

--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ Alternatively, the container image can be built with
   [hub]: https://hub.docker.com/repository/docker/whoi/phyto-arm
 
 
+#### Hot-patching packages in the container
+
+The Docker container allows you to overlay modified versions of ROS packages without rebuilding the entire container image. This is useful for testing changes to individual packages during development or troubleshooting.
+
+To test changes to the `aml_ctd` package without rebuilding the container:
+
+1. Make your changes to the package source on your host machine under `src/aml_ctd/`.
+
+2. Mount the *entire* package directory (containing the `package.xml` file) into the hot-patch workspace using a read-only bind mount:
+
+    ```bash
+    docker run --rm -it \
+        --mount type=bind,source="$(pwd)"/src/aml_ctd,target=/hot/ros1/src/aml_ctd,readonly \
+        # ... other docker options ...
+    ```
+
+    (If your container runtime does not support bind mounts, you can create a volume mapping with `--volume "$(pwd)"/src/aml_ctd:/hot/ros1/src/aml_ctd:ro`.)
+
+3. The container will build `aml_ctd` on startup and use your modified version instead of the built-in one.
+
+
 ### Install as a service
 
     sudo ln -sf $(pwd)/phyto-arm.service /etc/systemd/system/phyto-arm.service

--- a/deps/apt-requirements.txt
+++ b/deps/apt-requirements.txt
@@ -1,8 +1,0 @@
-# Dependencies should usually be declared in the package.xml file, to be
-# automatically installed by rosdep.
-build-essential
-git
-python3-catkin-tools
-python3-pip
-python3-rosdep
-python3-vcstool

--- a/deps/apt-rosdep-requirements.txt
+++ b/deps/apt-rosdep-requirements.txt
@@ -1,0 +1,23 @@
+# Auto-generated rosdep apt requirements
+# DO NOT EDIT MANUALLY - regenerate with scripts/generate-rosdep-requirements.sh
+#
+# Generated from:
+#   - deps/deps.rosinstall (VCS dependencies)
+#   - src/**/package.xml (local packages)
+#
+# Last updated: 2025-12-30 23:34:11 UTC
+#
+# To regenerate: ./scripts/generate-rosdep-requirements.sh
+# To verify: ./scripts/generate-rosdep-requirements.sh --verify
+
+gstreamer1.0-libav
+gstreamer1.0-rtsp
+libeigen3-dev
+python3-scipy
+ros-noetic-compressed-image-transport
+ros-noetic-control-msgs
+ros-noetic-cv-bridge
+ros-noetic-foxglove-msgs
+ros-noetic-gpsd-client
+ros-noetic-image-transport
+ros-noetic-rosbridge-server

--- a/deps/deps.rosinstall
+++ b/deps/deps.rosinstall
@@ -7,6 +7,7 @@
 - git:
     local-name: ds_msgs
     uri: https://bitbucket.org/whoidsl/ds_msgs.git
+    version: rzg/fix-cfg
 
 - git:
     local-name: ros-rtsp-camera

--- a/ros_entrypoint.sh
+++ b/ros_entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eo pipefail
+
+source /opt/ros/noetic/setup.bash
+source /app/install/setup.bash
+
+if [ -d /hot/ros1/src ] && [ -n "$(ls -A /hot/ros1/src 2>/dev/null)" ]; then
+    (
+        cd /hot/ros1
+
+        # Check dependencies - fail if any are missing
+        if ! rosdep check --from-paths ./src --ignore-src; then
+            echo ""
+            echo "ERROR: Hot-patch workspace has missing dependencies!"
+            echo "Required dependencies are not installed in this container."
+            echo ""
+            echo "Please rebuild the container with updated dependencies:"
+            echo "  1. Run: ./scripts/generate-rosdep-requirements.sh"
+            echo "  2. Rebuild: docker build --tag whoi/phyto-arm:latest ."
+            exit 1
+        fi
+
+        # Build packages in the hot-patch workspace
+        [ ! -f .catkin_workspace ] && catkin init
+        catkin config --extend /app/install --no-install --link-devel
+        catkin build
+    )
+
+    source /hot/ros1/devel/setup.bash
+fi
+
+exec "$@"

--- a/scripts/generate-rosdep-requirements.sh
+++ b/scripts/generate-rosdep-requirements.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Generate rosdep apt requirements file
+#
+# Usage:
+#   ./scripts/generate-rosdep-requirements.sh [OPTIONS]
+#
+# Options:
+#   --verify    Verify mode - check if existing file matches current deps
+#   --help      Show this help message
+#
+# Environment Variables:
+#   DOCKER      Container runtime to use (default: docker)
+
+set -euo pipefail
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_FILE="$PROJECT_ROOT/deps/apt-rosdep-requirements.txt"
+DOCKER=${DOCKER:-docker}
+VERIFY_MODE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verify)
+            VERIFY_MODE=true
+            shift
+            ;;
+        --help)
+            head -n 11 "$0" | tail -n +2 | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Run with --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Build the special container target for dumping requirements
+echo "Building container image with $DOCKER..."
+$DOCKER build --target generate-rosdep-requirements --tag phyto-arm:gen-deps . \
+    >/dev/null
+
+echo "Extracting rosdep requirements..."
+TEMP_PACKAGES=$(mktemp)
+$DOCKER run --rm phyto-arm:gen-deps > "$TEMP_PACKAGES"
+
+PACKAGE_COUNT=$(wc -l < "$TEMP_PACKAGES" | tr -d ' ')
+echo "Found $PACKAGE_COUNT packages"
+
+if [ "$VERIFY_MODE" = true ]; then
+    echo "Verifying $OUTPUT_FILE..."
+
+    if [ ! -f "$OUTPUT_FILE" ]; then
+        echo "ERROR: $OUTPUT_FILE does not exist!"
+        echo "Run without --verify to generate it."
+        rm "$TEMP_PACKAGES"
+        exit 1
+    fi
+
+    # Compare package lists (ignoring headers/comments/blank lines)
+    EXPECTED=$(grep -v '^#' "$OUTPUT_FILE" | grep -v '^$' | sort)
+    ACTUAL=$(sort "$TEMP_PACKAGES")
+
+    if [ "$EXPECTED" != "$ACTUAL" ]; then
+        echo "ERROR: $OUTPUT_FILE is out of date!"
+        echo ""
+        echo "Differences:"
+        diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true
+        echo ""
+        echo "To update, run: ./scripts/generate-rosdep-requirements.sh"
+        rm "$TEMP_PACKAGES"
+        exit 1
+    fi
+
+    rm "$TEMP_PACKAGES"
+    echo "✓ $OUTPUT_FILE is up to date"
+else
+    # Generate output file with header
+    TIMESTAMP=$(date -u "+%Y-%m-%d %H:%M:%S UTC")
+
+    cat > "$OUTPUT_FILE" <<EOF
+# Auto-generated rosdep apt requirements
+# DO NOT EDIT MANUALLY - regenerate with scripts/generate-rosdep-requirements.sh
+#
+# Generated from:
+#   - deps/deps.rosinstall (VCS dependencies)
+#   - src/**/package.xml (local packages)
+#
+# Last updated: $TIMESTAMP
+#
+# To regenerate: ./scripts/generate-rosdep-requirements.sh
+# To verify: ./scripts/generate-rosdep-requirements.sh --verify
+
+EOF
+
+    cat "$TEMP_PACKAGES" >> "$OUTPUT_FILE"
+    rm "$TEMP_PACKAGES"
+
+    echo "✓ Generated $OUTPUT_FILE with $PACKAGE_COUNT packages"
+fi

--- a/src/aml_ctd/CMakeLists.txt
+++ b/src/aml_ctd/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(
     ds_sensor_msgs
 )
 
+catkin_python_setup()
+
 add_message_files(
   FILES
   AmlMeasurement.msg
@@ -21,6 +23,11 @@ generate_messages(
 )
 
 catkin_package()
+
+catkin_install_python(
+  PROGRAMS src/aml_ctd_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 if (CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(tests)

--- a/src/aml_ctd/setup.py
+++ b/src/aml_ctd/setup.py
@@ -1,0 +1,10 @@
+## ! DO NOT MANUALLY INVOKE THIS FILE, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+setup_args = generate_distutils_setup(
+    py_modules=['amlxparser'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/src/dli_power_switch/CMakeLists.txt
+++ b/src/dli_power_switch/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(
     ds_core_msgs
 )
 
+catkin_python_setup()
+
 add_message_files(
   FILES
   OutletStatus.msg
@@ -20,6 +22,11 @@ generate_messages(
 )
 
 catkin_package()
+
+catkin_install_python(
+  PROGRAMS src/dli_power_switch_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 if (CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(tests)

--- a/src/dli_power_switch/setup.py
+++ b/src/dli_power_switch/setup.py
@@ -1,0 +1,10 @@
+## ! DO NOT MANUALLY INVOKE THIS FILE, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+setup_args = generate_distutils_setup(
+    py_modules=['api'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/src/jvl_motor/CMakeLists.txt
+++ b/src/jvl_motor/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(
     ds_core_msgs
 )
 
+catkin_python_setup()
+
 add_message_files(
   FILES
   Electrical.msg
@@ -31,6 +33,11 @@ generate_messages(
 )
 
 catkin_package()
+
+catkin_install_python(
+  PROGRAMS src/jvl_motor_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 if (CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(tests)

--- a/src/jvl_motor/setup.py
+++ b/src/jvl_motor/setup.py
@@ -1,0 +1,10 @@
+## ! DO NOT MANUALLY INVOKE THIS FILE, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+setup_args = generate_distutils_setup(
+    py_modules=['mac400'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/src/phyto_arm/CMakeLists.txt
+++ b/src/phyto_arm/CMakeLists.txt
@@ -37,8 +37,34 @@ generate_messages(
   ds_core_msgs
 )
 
+catkin_package()
+
+# Install all node executables
+catkin_install_python(
+  PROGRAMS
+    src/arm_base.py
+    src/arm_chanos.py
+    src/arm_ifcb.py
+    src/ifcb_runner.py
+    src/lock_manager.py
+    src/network_data_capture.py
+    src/profiler_node.py
+    src/web_node.py
+    src/winch_node.py
+    src/mocks/mock_ctd.py
+    src/mocks/mock_ifcb_runner.py
+    src/mocks/mock_profiler_node.py
+    src/mocks/mock_winch_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Install launch files
+install(
+  DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+  FILES_MATCHING PATTERN "*.launch"
+)
+
 if (CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(src/tests.py)
 endif()
-
-catkin_package()

--- a/src/rbr_maestro3_ctd/CMakeLists.txt
+++ b/src/rbr_maestro3_ctd/CMakeLists.txt
@@ -21,3 +21,8 @@ generate_messages(
 )
 
 catkin_package()
+
+catkin_install_python(
+  PROGRAMS src/rbr_maestro3_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
> [!NOTE]  
> This is part of a general project cleanup along the road to ROS 2.

We have historically shipped a container with package sources and build products, and run the packages out of the [devel space](https://wiki.ros.org/catkin/workspaces#Development_.28Devel.29_Space) rather than the [install space](https://wiki.ros.org/catkin/workspaces#Install_Space).

The devel space basically contains symlinks into the sources directory (for some Python code) or build products directory (for compiled code). Consequences of this include:

* You have to ship the `src` and `build` directories along with your packages. This includes intermediate build products plus the entire git history of every cloned repo, which take up ~a lot of~ space ~— it appears to **double** the size of the container image.~

* Updating a `src` file (for example, with a volume mount into a container) is convenient *but* doing so without triggering a rebuild (of, say, message definitions) can leave the package in an unsound state.

* Runtime dependencies can be conflated with build-time dependencies, creating hidden dependencies (a code smell) or bloated install base (by including compilers etc.)

In ROS2, the devel space doesn't exist anymore, and to achieve the same functionality you need to use `--symlink-install`.

**DX question:** How do we make it so it's still easy to mount source directories into the container? My suggestion is we have our entry point look for files in a certain workspace directory and, if populated, run `colcon build --symlink-install`. This should complete almost instantly for Python packages. Then, sourcing this workspace last will overlay the others and take priority. You will have to mount the entire package in, not just a single file.

- [x] Update entrypoint to set up the overlay workspace