### PR TITLE
Fix scaling constant for MAC400 RPM register

### DIFF
--- a/src/jvl_motor/src/mac400.py
+++ b/src/jvl_motor/src/mac400.py
@@ -76,8 +76,8 @@ all_registers = [
         encode=lambda x: pack('l', x),
     ),
     Register(name='V_SOLL',          num=5,
-        decode=lambda lo, hi: unpack('l', lo, hi) / 2.77056,  # RPM
-        encode=lambda x: pack('l', int(x * 2.77056)),
+        decode=lambda lo, hi: unpack('l', lo, hi) / 2.83989,  # RPM
+        encode=lambda x: pack('l', int(x * 2.83989)),
     ),
     Register(name='A_SOLL',          num=6,
         decode=lambda lo, hi: unpack('l', lo, hi) / 3.598133e-3,  # RPM/s


### PR DESCRIPTION
@figuernd pointed out that I used the scaling coefficient for the MAC800, which has 8000 encoder steps, rather than the MAC400, which has 8192.

Unfortunately the manual is inconsistent:

| | p.264 | p.424 |
| --- | --- | --- |
| **MAC400** | 2.837 | 2.771 | 
| **MAC800** | 2.83989 | 2.77056 | 

Here we see that for the MAC800, page 424 gives a more precise coefficient that agrees with the one on page 264.

For the MAC400, though, we can't just write off the value on page 264 as a rounding error. My guess is it was derived from:

$$\frac{8192}{8000} \times 2.77056 = 2.83705344$$

The scaling factor ought to just be the reciprocal $\frac{\mathtt{count}}{\mathtt{RPM}}$ from this table:

<img width="591" height="259" alt="image" src="https://github.com/user-attachments/assets/f86c81af-f775-4202-9cb7-a61f93b556c4" />

If the sampling frequency is 769.23 Hz, with an encoder resolution of 8000, and averaging over 16 samples, we can recalculate the entry in the above table as:

$$\frac{769.23\ \mathtt{Hz}}{8000\ \mathtt{counts}} \times \frac{60\ \mathtt{seconds\ per\ minute}}{16\ \mathtt{samples\ per\ count}} = 0.3605765625$$

And then just take the reciprocal to find ... 2.7733361067. Wait, that doesn't agree either! Instead, solving the other way, 2.77056 seems to be the right factor for 770 Hz:

$$\frac{8000\ \mathtt{counts}}{770\ \mathtt{Hz}} \times \frac{16\ \mathtt{samples\ per\ count}}{60\ \mathtt{seconds\ per\ minute}} = 2.7705627706$$

Uh, weird. So then for the MAC400 we have either:

$$\frac{8192\ \mathtt{counts}}{770\ \mathtt{Hz}} \times \frac{16\ \mathtt{samples\ per\ count}}{60\ \mathtt{seconds\ per\ minute}} = 2.8370562771$$
$$\frac{8192\ \mathtt{counts}}{769.23\ \mathtt{Hz}} \times \frac{16\ \mathtt{samples\ per\ count}}{60\ \mathtt{seconds\ per\ minute}} = 2.8398961732$$

So ... that is where the inconsistency comes from. Which do we believe, 770Hz or 769.23Hz? I don't know.

The maximum RPM is supposed to be around 3000 RPM. With a 0.1% difference between scaling factors it's a maximum difference of 3 RPM. I am deeply unsatisfied but I guess I have to live with it.

Fixes #99.