### PR TITLE
Reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV ROS_DISTRO=noetic
 
+# Only install packages we explicitly request
+RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-no-recommends
+
 # ROS Noetic reached end of life in May 2025, so packages are installed from
 # the final snapshot of the package archive.
 RUN echo 'Etc/UTC' > /etc/timezone \

--- a/Dockerfile
+++ b/Dockerfile
@@ -196,10 +196,12 @@ RUN python3 -m pip install --ignore-installed -r /launchpad/requirements.txt
 # Final build stage, leaving behind build-time dependencies
 FROM ros-base
 
-# Install only the dependencies needed to run the workspace
+# Install only runtime dependencies
 COPY --from=builder /app/src ./src
 RUN apt update \
- && rosdep install --default-yes --dependency-types exec --from-paths ./src --ignore-src \
+ && rosdep install --default-yes --dependency-types exec \
+        --skip-keys boost `# ds_asio wrongly declares exec dependency` \
+        --from-paths ./src --ignore-src \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy the built workspace, Python packages installed by pip, and the ROS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build our own slimmed-down version of ros:noetic
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS ros-base
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -42,6 +42,9 @@ RUN apt-get update \
 
 WORKDIR /app
 
+
+# Use an intermediate builder stage to compile dependencies
+FROM ros-base AS builder
 
 # Install apt package dependencies
 COPY deps/apt-requirements.txt ./
@@ -134,6 +137,22 @@ RUN bash -c "source devel/setup.bash \
 RUN mkdir -p /launchpad
 RUN curl -L http://github.com/WHOIGit/ros-launchpad/archive/v1.0.14.tar.gz | tar zxf - --strip-components=1 -C /launchpad
 RUN python3 -m pip install --ignore-installed -r /launchpad/requirements.txt
+
+
+# Final build stage, leaving behind build-time dependencies
+FROM ros-base
+
+# Install only the dependencies needed to run the workspace
+COPY --from=builder /app/src ./src
+RUN apt update \
+ && rosdep install --default-yes --dependency-types exec --from-paths ./src --ignore-src \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy the built workspace, Python packages installed by pip, and the ROS
+# Launchpad management server
+COPY --from=builder /app/devel ./devel
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /launchpad /launchpad
 
 # Copy the launch tools and server files
 COPY ./phyto-arm ./phyto-arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,41 @@
-FROM ros:noetic
+# Build our own slimmed-down version of ros:noetic
+FROM ubuntu:20.04
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV ROS_DISTRO=noetic
+
+# ROS Noetic reached end of life in May 2025, so packages are installed from
+# the final snapshot of the package archive.
+RUN echo 'Etc/UTC' > /etc/timezone \
+ && ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        tzdata \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /usr/share/keyrings \
+ && curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA' \
+        | gpg --dearmor > /usr/share/keyrings/ros1-snapshots-archive-keyring.gpg \
+ && rm -rf /root/.gnupg \
+ && echo "deb [ signed-by=/usr/share/keyrings/ros1-snapshots-archive-keyring.gpg ] http://snapshots.ros.org/noetic/final/ubuntu focal main" \
+        > /etc/apt/sources.list.d/ros1-snapshots.list
+
+# OpenMPI, a ROS dependency by way of Boost, requires a Fortran compiler, so
+# apt pulls in the LLVM Fortran compiler, which is massive. Block it so apt
+# selects GFortran instead (-1.11 GB).
+RUN printf 'Package: flang-18 libflang-18-dev\nPin: release *\nPin-Priority: -1\n' \
+        > /etc/apt/preferences.d/no-flang
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        python3-rosdep \
+        ros-noetic-ros-base=1.5.0-1* \
+ && rm -rf /var/lib/apt/lists/* \
+ && rosdep init \
+ && rosdep update --rosdistro $ROS_DISTRO
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,52 @@ RUN echo 'Etc/UTC' > /etc/timezone \
 RUN printf 'Package: flang-18 libflang-18-dev\nPin: release *\nPin-Priority: -1\n' \
         > /etc/apt/preferences.d/no-flang
 
+# Install a shim package that satisfies dependencies on -dev packages that
+# aren't really needed at runtime. The builder stage removes the shim and
+# installs the real packages. To maintain this list, find any -dev packages
+# in the final image and use 'apt-cache rdepends --installed' to see what
+# requires them.
+RUN mkdir -p /tmp/shim/DEBIAN \
+ && provides=$(echo \
+        cmake \
+        google-mock \
+        libapr1-dev \
+        libaprutil1-dev \
+        libboost-all-dev \
+        libboost-chrono-dev \
+        libboost-date-time-dev \
+        libboost-dev \
+        libboost-filesystem-dev \
+        libboost-program-options-dev \
+        libboost-regex-dev \
+        libboost-system-dev \
+        libboost-thread-dev \
+        libbz2-dev \
+        libconsole-bridge-dev \
+        libgpgme-dev \
+        libgtest-dev \
+        liblog4cxx-dev \
+        liblz4-dev \
+        libopencv-dev \
+        libpoco-dev \
+        libssl-dev \
+        libtinyxml2-dev \
+        libturbojpeg0-dev \
+        python3-dev \
+        uuid-dev \
+    | sed 's/ /, /g') \
+ && printf '%s\n' \
+        'Package: dev-dependency-shim' \
+        'Version: 1.0' \
+        'Architecture: all' \
+        'Maintainer: PhytO-ARM developers' \
+        "Provides: $provides" \
+        'Description: Stand-in for build-time dependencies of ROS packages' \
+        > /tmp/shim/DEBIAN/control \
+ && dpkg-deb --build /tmp/shim /tmp/shim.deb \
+ && dpkg -i /tmp/shim.deb \
+ && rm -rf /tmp/shim /tmp/shim.deb
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         python3-rosdep \
@@ -45,6 +91,14 @@ WORKDIR /app
 
 # Use an intermediate builder stage to compile dependencies
 FROM ros-base AS builder
+
+# The shim hides development packages that the builder needs, so remove it
+# and let apt install the real packages.
+RUN dpkg --remove --force-depends dev-dependency-shim \
+ && apt-get update \
+ && apt-get install -y --fix-broken --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
 
 # Install apt package dependencies
 COPY deps/apt-requirements.txt ./


### PR DESCRIPTION
I noticed that compressed container images suddenly ballooned from 600 MB to 900 MB, uncompressed something like 3.8 GB, which seems extraordinary for a project that is primarily Python scripts; `ubuntu:focal` itself is only 26 MB.

Claude tracked this down to a surprising change:

> The apt history log inside the image shows exactly how it got there: ros-noetic-ros-core depends (through rosbag → Boost.MPI → mpi-default-dev → libopenmpi-dev) on the virtual package gfortran-mod-15. Historically only gfortran-9/-10 provided that, but Ubuntu backported LLVM 18 to focal-updates in 2025 (1:18.1.8-11~20.04.2, built for their Firefox toolchain), and flang-18 also provides gfortran-mod-15. With no real provider installed, apt picked flang-18 — the alphabetically-first provider — over the ~30 MB gfortran. So the Dockerfile didn't change; any rebuild after that backport landed silently gained ~1.5 GB of compressed layers. The image on Docker Hub was built 2025-06-09, after the backport.

So I set the bot to work fixing this and looking for other opportunities to save space, and it clawed back 2.39 GB out of the image through a couple of tricks:

1. Build our own ROS Noetic base image that excludes flang
2. Stop installing "recommended" packages; we should declare what we need.
3. Stop depending on boost at runtime (a ds_asio bug that probably won't get fixed).
4. Use a final stage that doesn't include dependencies we don't need.
5. Remove the pip download cache after we've installed dependencies.

I'm slightly skeptical about the shim package idea but it should be easy to test.