### PR TITLE
Fix rosbag exclusion pattern for image topics

### DIFF
--- a/src/phyto_arm/launch/rosbag.launch
+++ b/src/phyto_arm/launch/rosbag.launch
@@ -13,5 +13,5 @@ timestamps, or generate reports. See http://wiki.ros.org/rosbag/Cookbook
     <arg name="rosbag_duration" default="60m" />
 
     <node name="rosbag_record" pkg="rosbag" type="record"
-        args="$(eval 'record --all --exclude /camera/.*|/ifcb/image|/ifcb/in|/ifcb/roi/.*|/rosout_agg --output-prefix ' + arg('rosbag_prefix') + (' --split --size ' + str(arg('rosbag_size')) if arg('rosbag_size') else '') + (' --split --duration ' + str(arg('rosbag_duration')) if arg('rosbag_duration') else '') + ' --publish --lz4')" />
+        args="$(eval 'record --all --exclude /camera/.*|/ifcb/image|/ifcb/image/.*|/ifcb/in|/ifcb/roi|/ifcb/roi/.*|/rosout_agg --output-prefix ' + arg('rosbag_prefix') + (' --split --size ' + str(arg('rosbag_size')) if arg('rosbag_size') else '') + (' --split --duration ' + str(arg('rosbag_duration')) if arg('rosbag_duration') else '') + ' --publish --lz4')" />
 </launch>


### PR DESCRIPTION
IFCB110 was generating large rosbags at ~800MB/hr because `/ifcb/image/compressed` is being included. This is probably a regression due to b74b573.

This change was applied in the field and is pending confirmation that this resolves the issue.